### PR TITLE
Add proper script-load support for JSC

### DIFF
--- a/lib/ConsoleRunner.js
+++ b/lib/ConsoleRunner.js
@@ -12,6 +12,14 @@ class ConsoleRunner extends Runner {
     this.printCommand = 'print';
   }
 
+  receiveOut(cp, str) {
+    return str;
+  }
+
+  receiveErr(cp, str) {
+    return str;
+  }
+
   exec(code) {
     const d = deferred();
     const tempfile = temp.path({ suffix: '.js' });
@@ -24,8 +32,8 @@ class ConsoleRunner extends Runner {
       let stdout = '';
       let stderr = '';
 
-      cp.stdout.on('data', function (str) { stdout += str });
-      cp.stderr.on('data', function (str) { stderr += str });
+      cp.stdout.on('data', str => { stdout += this.receiveOut(cp, str) });
+      cp.stderr.on('data', str => { stderr += this.receiveErr(cp, str) });
       cp.on('close', function () {
         fs.unlink(tempfile);
 

--- a/lib/JSCRunner.js
+++ b/lib/JSCRunner.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const temp = require('temp');
 const inception = require('./inception');
 const ConsoleRunner = require('./ConsoleRunner');
 
@@ -19,9 +20,20 @@ const errorRe = /^(?:.*?): (\w+)(?:: (.*))$/m;
 // EvalMarker: `eval code`
 const frameRe = /(?:(.*)@)?(\[native code\]|(?:(.*):(\d+):(\d+)))/;
 
+const scriptStartMarker = '<<< SCRIPT START >>>';
+const scriptEndMarker = '<<< SCRIPT END >>>';
+
+const tempScriptFile = temp.path({ suffix: '.js' });
+process.addListener('exit', function() {
+  try { fs.unlinkSync(tempScriptFile); } catch (e) { /* ignore */ }
+});
+
 const runtimeStr = inception(
   fs.readFileSync(__dirname + '/../runtimes/jsc.js', 'utf8')
     .replace('$FILE', JSON.stringify(__dirname + '/../runtimes/jsc-create.js'))
+    .replace('$SCRIPT_FILE', JSON.stringify(tempScriptFile))
+    .replace('$SCRIPT_START_MARKER', JSON.stringify(scriptStartMarker))
+    .replace('$SCRIPT_END_MARKER', JSON.stringify(scriptEndMarker))
     .replace(/\r?\n/g, '')
 );
 
@@ -59,6 +71,52 @@ function parseStack(stackStr) {
 }
 
 class JSCRunner extends ConsoleRunner {
+  receiveOut(cp, str) {
+    str = String(str);
+
+    let script, out;
+    if (!this.scriptBuffer) {
+      // Search for script start marker.
+      let start = str.indexOf(scriptStartMarker);
+      if (start === -1) {
+        out = str;
+      } else {
+        out = str.substring(0, start);
+
+        let scriptStart = start + scriptStartMarker.length;
+        let scriptEnd = str.indexOf(scriptEndMarker);
+        if (scriptEnd === -1) {
+          // Incomplete load script, buffer content in 'scriptBuffer'.
+          this.scriptBuffer = str.substring(scriptStart);
+        } else {
+          script = str.substring(scriptStart, scriptEnd);
+        }
+      }
+    } else {
+      out = '';
+
+      // Search script end marker.
+      let scriptEnd = str.indexOf(scriptEndMarker);
+      if (scriptEnd === -1) {
+        this.scriptBuffer += str;
+      } else {
+        script = this.scriptBuffer + str.substring(0, scriptEnd);
+        this.scriptBuffer = null;
+      }
+    }
+
+    if (script) {
+      fs.writeFile(tempScriptFile, script, err => {
+        if (err) throw err;
+
+        // Unblock script execution.
+        cp.stdin.write('\n');
+      });
+    }
+
+    return out;
+  }
+
   parseError(str) {
     const match = str.match(errorRe);
 

--- a/runtimes/jsc.js
+++ b/runtimes/jsc.js
@@ -27,8 +27,14 @@ var $ = {
   },
   evalInNewScript(code, errorCb) {
     try {
-      /* FIXME: `code` should be executed as a global script, not an eval script. */
-      this.global.eval(code);
+      print(this.scriptStartMarker);
+      print(code);
+      print(this.scriptEndMarker);
+
+      /* Blocks until the script is written to the file system. */
+      readline();
+
+      load(this.scriptFile);
     } catch (e) {
       if (errorCb) errorCb(e);
     }
@@ -40,5 +46,8 @@ var $ = {
     this.global[name] = value;
   },
   source: $SOURCE,
-  file: $FILE
+  file: $FILE,
+  scriptFile: $SCRIPT_FILE,
+  scriptStartMarker: $SCRIPT_START_MARKER,
+  scriptEndMarker: $SCRIPT_END_MARKER,
 };

--- a/test/runify.js
+++ b/test/runify.js
@@ -157,10 +157,6 @@ hosts.forEach(function (record) {
     });
 
     it('can eval lexical bindings in new scripts', function () {
-      if (type === 'jsc') {
-        // Skip test for JavaScriptCore, see fixme in runtimes/jsc.js.
-        this.skip();
-      }
       return runner.exec(`
         $.evalInNewScript("'use strict'; let x = 3;");
         print(x);


### PR DESCRIPTION
Another workaround for missing JSC shell built-ins: The built-in `load()` function executes source code as a script, so just what we need for our `evalInNewScript` function (yay!). But `load()` only accepts a file parameter and JSC doesn't provide a built-in function to write to files (meh!). As a workaround I'm simply delegating the file write access to the node process. 