### PR TITLE
Don't crash when unable to parse error props

### DIFF
--- a/lib/parseError.js
+++ b/lib/parseError.js
@@ -15,6 +15,7 @@ function parse(str) {
 
   const errorStr = match[0];
   match = errorStr.match(errorPropsRe);
+  if (!match) return null;
 
   return {
     name: match[1],


### PR DESCRIPTION
I ran into a failure here when running the test suite. I assume returning null on a bad error props match is OK because this code was already returning null on line 13. But perhaps that is a bad assumption?