### PR TITLE
Allow a transpiler to be provided for an agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Gets an instance of a runner for a particular host type. See the table above for
 
 * **hostPath**: Path to host to execute. For console hosts, this argument is required. For the specific browser runners, hostPath is optional and if omitted, the location for that browser will be detected automatically.
 * **hostArguments**:  Command line arguments used when invoking your host. Not supported for browser hosts. **hostArguments** is an array of strings as you might pass to Node's spawn API.
+* **transform**: A function to map the source to some other source before running the result on the underlying host.
 
 ### Agent API
 #### initialize(): Promise<void>

--- a/lib/Agent.js
+++ b/lib/Agent.js
@@ -9,7 +9,7 @@ class Agent {
     this.options = options;
     this.hostPath = options.hostPath;
     this.args = options.hostArguments || [];
-    this.transpiler = options.transpiler || (x => x);
+    this.transform = options.transform || (x => x);
 
     if (typeof this.args === 'string') {
       this.args = this.args.includes(' ') ?
@@ -21,7 +21,7 @@ class Agent {
   compile(code, options) {
     options = options || {};
 
-    code = this.transpiler(code);
+    code = this.transform(code);
 
     if (options.async) {
       return code;

--- a/lib/Agent.js
+++ b/lib/Agent.js
@@ -9,6 +9,7 @@ class Agent {
     this.options = options;
     this.hostPath = options.hostPath;
     this.args = options.hostArguments || [];
+    this.transpiler = options.transpiler || (x => x);
 
     if (typeof this.args === 'string') {
       this.args = this.args.includes(' ') ?
@@ -19,6 +20,8 @@ class Agent {
 
   compile(code, options) {
     options = options || {};
+
+    code = this.transpiler(code);
 
     if (options.async) {
       return code;

--- a/test/runify.js
+++ b/test/runify.js
@@ -338,10 +338,10 @@ hosts.forEach(function (record) {
     this.timeout(20000);
 
     let agent;
-    function transpiler(x) { return `print("${x}")`; }
+    function transform(x) { return `print("${x}")`; }
 
     before(function() {
-      let options = { hostPath: host, transpiler }
+      let options = { hostPath: host, transform }
       return runify.createAgent(type, options).then(a => agent = a);
     });
 
@@ -349,7 +349,7 @@ hosts.forEach(function (record) {
       return agent.destroy();
     });
 
-    it('runs transpilers', function () {
+    it('runs transforms', function () {
       return agent.evalScript('foo').then(function(result) {
         assert(result.stdout.match(/^foo\r?\n/), 'Unexpected stdout: ' + result.stdout);
       });

--- a/test/runify.js
+++ b/test/runify.js
@@ -333,4 +333,26 @@ hosts.forEach(function (record) {
       })
     })
   });
+
+  describe(`${type} (${host})`, function () {
+    this.timeout(20000);
+
+    let agent;
+    function transpiler(x) { return `print("${x}")`; }
+
+    before(function() {
+      let options = { hostPath: host, transpiler }
+      return runify.createAgent(type, options).then(a => agent = a);
+    });
+
+    after(function() {
+      return agent.destroy();
+    });
+
+    it('runs transpilers', function () {
+      return agent.evalScript('foo').then(function(result) {
+        assert(result.stdout.match(/^foo\r?\n/), 'Unexpected stdout: ' + result.stdout);
+      });
+    });
+  });
 });


### PR DESCRIPTION
The purpose of this change is to allow transpilation, e.g., with Babel, e.g., to run test262 tests, as in this tree https://github.com/littledan/test262-harness/tree/babel