### PR TITLE
Avoid timeout bug in Socket.io

### DIFF
--- a/lib/WebdriverAgent.js
+++ b/lib/WebdriverAgent.js
@@ -63,7 +63,7 @@ class WebdriverAgent extends BrowserAgent {
       baseP = this._restartP;
     }
 
-    return baseP.then(_ => super.destroy()).then(_ => this._driver.quit());
+    return baseP.then(_ => this._driver.quit()).then(_ => super.destroy());
   }
 }
 


### PR DESCRIPTION
When a Socket.io server with active connections is destroyed, it may
fail to clear long-running internal timers. The process will not exit
while such timers are active, causing significant delays between server
destruction and process termination.

Re-order the sequence of actions in the WebDriverAgent's `destroy`
method to first end the browsing session (allowing all Socket.io-related
timers to be cleared) and then destroy the Socket.io server.