### PR TITLE
Make tests runnable outside of Brian's computer ;)

### DIFF
--- a/test/runify.js
+++ b/test/runify.js
@@ -2,7 +2,11 @@
 
 const runify = require('../');
 const assert = require('assert');
+const cp = require('child_process');
+const path = require('path');
+const os = require('os');
 
+// Default Hosts (as seen on windows)
 const hosts = [
   ['./hosts/js.exe', 'jsshell'],
   ['./hosts/ch.exe', 'ch'],
@@ -10,12 +14,27 @@ const hosts = [
   ['../v8/build/Release/d8.exe', 'd8'],
   ['../webkit/build/bin64/jsc.exe', 'jsc'],
   /*[undefined, 'chrome'],*/
-  
+
   //['C:/Program Files (x86)/Mozilla Firefox/firefox.exe', 'firefox'],
   /*['C:/Program Files (x86)/Nightly/firefox.exe', 'firefox'],
   ['C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe', 'chrome'],
   */
 ];
+
+if (os.platform() !== 'win32') {
+  hosts.forEach((record, index) => {
+    const [ host, type ] = record;
+    let bin = type;
+
+    if (!host.endsWith(`${bin}.exe`)) {
+      bin = path.basename(host, '.exe');
+    }
+
+    try {
+      hosts[index][0] = cp.execSync(`which ${bin}`).toString().trim();
+    } catch (error) {}
+  });
+}
 
 const timeout = function(ms) {
   return new Promise(res => {


### PR DESCRIPTION
With this patch, I can run the "runify" tests with the JS engines compiled/installed on my local: 

```
$ npm test

> eshost@3.4.2 test /Users/rwaldron/clonez/eshost
> mocha test/*



  Agent
    Agent({ hostArguments })
      ✓ accepts a single item string of hostArguments
      ✓ a multiple item string of space delimited hostArguments
      ✓ accepts a single item array of hostArguments
      ✓ a multiple item array of hostArguments
      ✓ is forgiving of excessive spaces in hostArguments

  jsshell (/usr/local/bin/js)
    ✓ allows custom shortNames (55ms)
    ✓ runs SyntaxErrors (44ms)
    ✓ runs thrown SyntaxErrors (44ms)
    ✓ runs thrown TypeErrors (46ms)
    ✓ runs thrown RangeErrors (46ms)
    ✓ runs thrown Errors (45ms)
    ✓ runs thrown custom Errors (47ms)
    ✓ runs thrown custom Errors that don't have Error.prototype (47ms)
    ✓ runs thrown Errors without messages (45ms)
    ✓ runs thrown errors from eval (46ms)
    ✓ gathers stdout (44ms)
    ✓ can eval in new realms (46ms)
    ✓ can create new realms (49ms)
    ✓ can set globals in new realms (46ms)
    ✓ can eval in new scripts (47ms)
    ✓ returns errors from evaling in new script (47ms)
    ✓ can eval lexical bindings in new scripts (47ms)
    ✓ can set properties in new realms (46ms)
    ✓ can access properties from new realms (49ms)
    ✓ runs async code (45ms)
    ✓ accepts destroy callbacks (45ms)
    ✓ runs in the proper mode (276ms)
    ✓ can kill infinite loops (106ms)

  ch (/usr/local/bin/ch)
    ✓ allows custom shortNames
    ✓ runs SyntaxErrors
    ✓ runs thrown SyntaxErrors
    ✓ runs thrown TypeErrors
    ✓ runs thrown RangeErrors
    ✓ runs thrown Errors
    ✓ runs thrown custom Errors
    ✓ runs thrown custom Errors that don't have Error.prototype
    ✓ runs thrown Errors without messages
    ✓ runs thrown errors from eval
    ✓ gathers stdout
    ✓ can eval in new realms
    ✓ can create new realms
    ✓ can set globals in new realms
    ✓ can eval in new scripts
    ✓ returns errors from evaling in new script
    ✓ can eval lexical bindings in new scripts
    ✓ can set properties in new realms
    ✓ can access properties from new realms
    ✓ runs async code
    ✓ accepts destroy callbacks
    ✓ runs in the proper mode (132ms)
    ✓ can kill infinite loops (107ms)

  node (/usr/local/bin/node)
    ✓ allows custom shortNames (69ms)
    ✓ runs SyntaxErrors (57ms)
    ✓ runs thrown SyntaxErrors (57ms)
    ✓ runs thrown TypeErrors (56ms)
    ✓ runs thrown RangeErrors (56ms)
    ✓ runs thrown Errors (55ms)
    ✓ runs thrown custom Errors (57ms)
    ✓ runs thrown custom Errors that don't have Error.prototype (57ms)
    ✓ runs thrown Errors without messages (55ms)
    ✓ runs thrown errors from eval (60ms)
    ✓ gathers stdout (69ms)
    ✓ can eval in new realms (73ms)
    ✓ can create new realms (72ms)
    ✓ can set globals in new realms (71ms)
    ✓ can eval in new scripts (73ms)
    ✓ returns errors from evaling in new script (72ms)
    ✓ can eval lexical bindings in new scripts (72ms)
    ✓ can set properties in new realms (75ms)
    ✓ can access properties from new realms (76ms)
    ✓ runs async code (68ms)
    ✓ accepts destroy callbacks (75ms)
    ✓ runs in the proper mode (433ms)
    ✓ can kill infinite loops (104ms)

  d8 (/Users/rwaldron/clonez/v8/out.gn/x64.release/d8)
    ✓ allows custom shortNames
    ✓ runs SyntaxErrors
    ✓ runs thrown SyntaxErrors
    ✓ runs thrown TypeErrors
    ✓ runs thrown RangeErrors
    ✓ runs thrown Errors
    ✓ runs thrown custom Errors
    ✓ runs thrown custom Errors that don't have Error.prototype
    ✓ runs thrown Errors without messages
    ✓ runs thrown errors from eval
    ✓ gathers stdout
    ✓ can eval in new realms
    ✓ can create new realms
    ✓ can set globals in new realms
    ✓ can eval in new scripts
    ✓ returns errors from evaling in new script
    ✓ can eval lexical bindings in new scripts
    ✓ can set properties in new realms
    ✓ can access properties from new realms
    ✓ runs async code
    ✓ accepts destroy callbacks
    ✓ runs in the proper mode (174ms)
    ✓ can kill infinite loops (103ms)

  jsc (/usr/local/bin/jsc)
    ✓ allows custom shortNames
    ✓ runs SyntaxErrors
    ✓ runs thrown SyntaxErrors
    ✓ runs thrown TypeErrors
    ✓ runs thrown RangeErrors
    ✓ runs thrown Errors
    ✓ runs thrown custom Errors
    ✓ runs thrown custom Errors that don't have Error.prototype
    ✓ runs thrown Errors without messages
    ✓ runs thrown errors from eval
    ✓ gathers stdout
    ✓ can eval in new realms
    ✓ can create new realms
    ✓ can set globals in new realms
    ✓ can eval in new scripts
    ✓ returns errors from evaling in new script
    ✓ can eval lexical bindings in new scripts
    ✓ can set properties in new realms
    ✓ can access properties from new realms
    ✓ runs async code
    ✓ accepts destroy callbacks
    ✓ runs in the proper mode (83ms)
    ✓ can kill infinite loops (107ms)


  120 passing (5s)
```




Signed-off-by: Rick Waldron <waldron.rick@gmail.com>