### PR TITLE
Allow a transpiler to be provided for an agent (rebased)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Gets an instance of a runner for a particular host type. See the table above for
 
 * **hostPath**: Path to host to execute. For console hosts, this argument is required. For the specific browser runners, hostPath is optional and if omitted, the location for that browser will be detected automatically.
 * **hostArguments**:  Command line arguments used when invoking your host. Not supported for browser hosts. **hostArguments** is an array of strings as you might pass to Node's spawn API.
+* **transform**: A function to map the source to some other source before running the result on the underlying host.
 
 ### Agent API
 #### initialize(): Promise<void>

--- a/lib/Agent.js
+++ b/lib/Agent.js
@@ -9,7 +9,7 @@ class Agent {
     this.options = options;
     this.hostPath = options.hostPath;
     this.args = options.hostArguments || [];
-    this.transpiler = options.transpiler || (x => x);
+    this.transform = options.transform || (x => x);
 
     if (typeof this.args === 'string') {
       this.args = this.args.includes(' ') ?
@@ -23,7 +23,7 @@ class Agent {
   compile(code, options) {
     options = options || {};
 
-    code = this.transpiler(code);
+    code = this.transform(code);
 
     if (options.async) {
       return code;

--- a/lib/Agent.js
+++ b/lib/Agent.js
@@ -9,6 +9,7 @@ class Agent {
     this.options = options;
     this.hostPath = options.hostPath;
     this.args = options.hostArguments || [];
+    this.transpiler = options.transpiler || (x => x);
 
     if (typeof this.args === 'string') {
       this.args = this.args.includes(' ') ?
@@ -21,6 +22,8 @@ class Agent {
 
   compile(code, options) {
     options = options || {};
+
+    code = this.transpiler(code);
 
     if (options.async) {
       return code;

--- a/test/runify.js
+++ b/test/runify.js
@@ -368,6 +368,11 @@ hosts.forEach(function (record) {
     function transform(x) { return `print("${x}")`; }
 
     before(function() {
+      if (process.env['ESHOST_SKIP_' + host.toUpperCase()]) {
+        this.skip();
+        return;
+      }
+
       let options = { hostPath: host, transform }
       return runify.createAgent(type, options).then(a => agent = a);
     });

--- a/test/runify.js
+++ b/test/runify.js
@@ -360,4 +360,26 @@ hosts.forEach(function (record) {
       })
     })
   });
+
+  describe(`${type} (${host})`, function () {
+    this.timeout(20000);
+
+    let agent;
+    function transpiler(x) { return `print("${x}")`; }
+
+    before(function() {
+      let options = { hostPath: host, transpiler }
+      return runify.createAgent(type, options).then(a => agent = a);
+    });
+
+    after(function() {
+      return agent.destroy();
+    });
+
+    it('runs transpilers', function () {
+      return agent.evalScript('foo').then(function(result) {
+        assert(result.stdout.match(/^foo\r?\n/), 'Unexpected stdout: ' + result.stdout);
+      });
+    });
+  });
 });

--- a/test/runify.js
+++ b/test/runify.js
@@ -365,10 +365,10 @@ hosts.forEach(function (record) {
     this.timeout(20000);
 
     let agent;
-    function transpiler(x) { return `print("${x}")`; }
+    function transform(x) { return `print("${x}")`; }
 
     before(function() {
-      let options = { hostPath: host, transpiler }
+      let options = { hostPath: host, transform }
       return runify.createAgent(type, options).then(a => agent = a);
     });
 
@@ -376,7 +376,7 @@ hosts.forEach(function (record) {
       return agent.destroy();
     });
 
-    it('runs transpilers', function () {
+    it('runs transforms', function () {
       return agent.evalScript('foo').then(function(result) {
         assert(result.stdout.match(/^foo\r?\n/), 'Unexpected stdout: ' + result.stdout);
       });


### PR DESCRIPTION
This is a rebased version of the changeset initially submitted by @littledan in gh-19. As noted in that discussion, recent changes in `master` necessitated a rebase and subsequent modification (see the final commit on this branch).

Supersedes gh-19.