### PR TITLE
Avoid race condition in `ConsoleAgent#stop`

### DIFF
--- a/lib/ConsoleAgent.js
+++ b/lib/ConsoleAgent.js
@@ -11,6 +11,10 @@ class ConsoleAgent extends Agent {
   constructor(options) {
     super(options);
     this.printCommand = 'print';
+
+    // Promise for the child process created by the most recent invocation of
+    // `evalScript`
+    this._cp = null;
   }
 
   createChildProcess(args = []) {
@@ -26,37 +30,38 @@ class ConsoleAgent extends Agent {
   }
 
   evalScript(code) {
-    const d = deferred();
     const tempfile = temp.path({ suffix: '.js' });
 
     code = this.compile(code);
-    writeFile(tempfile, code)
-    .then(_ => {
-      this._cp = this.createChildProcess([tempfile]);
+    this._cp = writeFile(tempfile, code)
+      .then(_ => this.createChildProcess([tempfile]));
+
+    return this._cp.then(child => {
       let stdout = '';
       let stderr = '';
 
-      this._cp.stdout.on('data', str => { stdout += this.receiveOut(this._cp, str); });
-      this._cp.stderr.on('data', str => { stderr += this.receiveErr(this._cp, str); });
-      this._cp.on('close', () => {
-        this._cp = null;
-        fs.unlink(tempfile, function () { /* ignore */ });
+      child.stdout.on('data', str => { stdout += this.receiveOut(child, str); });
+      child.stderr.on('data', str => { stderr += this.receiveErr(child, str); });
 
-        const result = this.normalizeResult({ stderr: stderr, stdout: stdout });
-
-        result.error = this.parseError(result.stderr);
-        d.resolve(result);
+      return new Promise(resolve => {
+        child.on('close', () => {
+          resolve({stdout, stderr});
+        });
       });
-    }).catch(err => {
-      d.reject(err);
-    });
+    }).then(({stdout, stderr}) => {
+      fs.unlink(tempfile, function () { /* ignore */ });
 
-    return d.promise;
+      const result = this.normalizeResult({ stderr: stderr, stdout: stdout });
+
+      result.error = this.parseError(result.stderr);
+
+      return result;
+    });
   }
 
   stop() {
     if (this._cp) {
-      this._cp.kill('SIGKILL');
+      this._cp.then(child => child.kill('SIGKILL'));
     }
 
     // killing is fast, don't bother waiting for it
@@ -100,16 +105,6 @@ class ConsoleAgent extends Agent {
 }
 
 module.exports = ConsoleAgent;
-
-function deferred() {
-  let res, rej;
-  const p = new Promise(function (resolve, reject) {
-    res = resolve;
-    rej = reject;
-  });
-
-  return { promise: p, resolve: res, reject: rej };
-}
 
 function promisify(api) {
   return function () {

--- a/lib/WebdriverAgent.js
+++ b/lib/WebdriverAgent.js
@@ -48,7 +48,8 @@ class WebdriverAgent extends BrowserAgent {
     this._driver = newDriver;
     const getP = newDriver.get(this._url);
     Server.clientIdStopped(this.id);
-    this._restartP = Promise.all([quitP, getP]);
+    this._restartP = super.stop()
+      .then(() => Promise.all([quitP, getP]));
     return this._restartP.then(_ => {
       this._restartP = null;
       return undefined;

--- a/lib/agents/BrowserAgent.js
+++ b/lib/agents/BrowserAgent.js
@@ -18,13 +18,32 @@ class BrowserAgent extends Agent {
         `?clientId=${this.id}&shortName=${this.shortName}`;
       return this;
     });
+
+    // A method for cancelling the current `evalScript` operation (if any)
+    this._cancelEval = null;
   }
 
   evalScript (code, options) {
     code = this.compile(code, options);
-    return Server.waitForClientId(this.id).then(handler => {
+    let cancelled = false;
+    const whenCancelled = new Promise(resolve => {
+      this._cancelEval = () => {
+        cancelled = true;
+        resolve({ stdout: '', stderr: '', error: null });
+      };
+    });
+
+    const whenEvaluated = Server.waitForClientId(this.id).then(handler => {
+      if (cancelled) {
+        return;
+      }
+
       handler._socket.emit('exec', code);
       return Server.waitForResult(this.id).then(result => {
+        if (cancelled) {
+          return;
+        }
+
         // normalize empty string to undefined
         if (result.error) {
           result.error.message = result.error.message || undefined;
@@ -33,6 +52,16 @@ class BrowserAgent extends Agent {
         return result;
       })
     });
+
+    return Promise.race([whenEvaluated, whenCancelled]);
+  }
+
+  stop() {
+    if (this._cancelEval) {
+      this._cancelEval();
+    }
+
+    return Promise.resolve();
   }
 
   destroy() {

--- a/test/runify.js
+++ b/test/runify.js
@@ -424,6 +424,20 @@ hosts.forEach(function (record) {
             });
       });
 
+      // The host may need to perform a number of asynchronous operations in
+      // order to evaluate a script. If the `stop` method is invoked while
+      // these operations are taking place, the host should not evaluate the
+      // script.
+      it('avoids race conditions in `stop`', function () {
+        const evalScript = agent.evalScript('print(1);');
+
+        agent.stop();
+
+        return evalScript.then(result => {
+          assert.equal(result.stdout, '');
+        });
+      });
+
       // mostly this test shouldn't hang (if it hangs, it's a bug)
       it('can kill infinite loops', function () {
         // The GeckoDriver project cannot currently destroy browsing sessions


### PR DESCRIPTION
The host may need to perform a number of asynchronous operations in
order to evaluate a script. If the `stop` method is invoked while these
operations are taking place, the host should not evaluate the script.

---

Hey @bterlson! I stumbled across this bug while working on that new version of
the `test262-harness` Node.js API we talked about a couple weeks ago.