### PR TITLE
Update runtime scripts for JSC, V8, and SpiderMonkey

### DIFF
--- a/lib/agents/jsc.js
+++ b/lib/agents/jsc.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const fs = require('fs');
-const temp = require('temp');
-const runtimePath = require('../runtimePath');
 const inception = require('../inception');
+const runtimePath = require('../runtimePath');
 const ConsoleAgent = require('../ConsoleAgent');
 
 const errorRe = /(?:.*?): (\w+)(?:: (.*))?(?:\r?\nat[^\n]*)?(\r?\n.*@(\[native code\]|(?:.*:\d+:\d+)))*\r?\n/;
@@ -21,20 +20,8 @@ const errorRe = /(?:.*?): (\w+)(?:: (.*))?(?:\r?\nat[^\n]*)?(\r?\n.*@(\[native c
 // EvalMarker: `eval code`
 const frameRe = /(?:(.*)@)?(\[native code\]|(?:(.*):(\d+):(\d+)))/;
 
-const scriptStartMarker = '<<< SCRIPT START >>>';
-const scriptEndMarker = '<<< SCRIPT END >>>';
-
-const tempScriptFile = temp.path({ suffix: '.js' });
-process.addListener('exit', function() {
-  try { fs.unlinkSync(tempScriptFile); } catch (e) { /* ignore */ }
-});
-
 const runtimeStr = inception(
   fs.readFileSync(runtimePath.for('jsc'), 'utf8')
-    .replace('$FILE', JSON.stringify(runtimePath.for('jsc-create')))
-    .replace('$SCRIPT_FILE', JSON.stringify(tempScriptFile))
-    .replace('$SCRIPT_START_MARKER', JSON.stringify(scriptStartMarker))
-    .replace('$SCRIPT_END_MARKER', JSON.stringify(scriptEndMarker))
     .replace(/\r?\n/g, '')
 );
 
@@ -73,52 +60,6 @@ function parseStack(stackStr) {
 }
 
 class JSCAgent extends ConsoleAgent {
-  receiveOut(cp, str) {
-    str = String(str);
-
-    let script, out;
-    if (!this.scriptBuffer) {
-      // Search for script start marker.
-      let start = str.indexOf(scriptStartMarker);
-      if (start === -1) {
-        out = str;
-      } else {
-        out = str.substring(0, start);
-
-        let scriptStart = start + scriptStartMarker.length;
-        let scriptEnd = str.indexOf(scriptEndMarker);
-        if (scriptEnd === -1) {
-          // Incomplete load script, buffer content in 'scriptBuffer'.
-          this.scriptBuffer = str.substring(scriptStart);
-        } else {
-          script = str.substring(scriptStart, scriptEnd);
-        }
-      }
-    } else {
-      out = '';
-
-      // Search script end marker.
-      let scriptEnd = str.indexOf(scriptEndMarker);
-      if (scriptEnd === -1) {
-        this.scriptBuffer += str;
-      } else {
-        script = this.scriptBuffer + str.substring(0, scriptEnd);
-        this.scriptBuffer = null;
-      }
-    }
-
-    if (script) {
-      fs.writeFile(tempScriptFile, script, err => {
-        if (err) throw err;
-
-        // Unblock script execution.
-        cp.stdin.write('\n');
-      });
-    }
-
-    return out;
-  }
-
   parseError(str) {
     const match = str.match(errorRe);
 

--- a/runtimes/jsc-create.js
+++ b/runtimes/jsc-create.js
@@ -1,2 +1,0 @@
-// arguments[0] is the callback function defined in $.createRealm().
-arguments[0](this);

--- a/runtimes/jsc.js
+++ b/runtimes/jsc.js
@@ -4,10 +4,7 @@ var $ = {
     options = options || {};
     options.globals = options.globals || {};
 
-    var realm;
-    run(this.file, function(newRealm) {
-      realm = newRealm;
-    });
+    var realm = createGlobalObject();
     realm.eval(this.source);
     realm.$.source = this.source;
     realm.$.destroy = function () {
@@ -15,23 +12,15 @@ var $ = {
         options.destroy();
       }
     };
-
     for(var glob in options.globals) {
       realm.$.global[glob] = options.globals[glob];
     }
 
     return realm.$;
   },
-  evalScript(code, errorCb) {
+  evalScript(code) {
     try {
-      print(this.scriptStartMarker);
-      print(code);
-      print(this.scriptEndMarker);
-
-      /* Blocks until the script is written to the file system. */
-      readline();
-
-      load(this.scriptFile);
+      loadString(code);
       return { type: 'normal', value: undefined };
     } catch (e) {
       return { type: 'throw', value: e }
@@ -46,8 +35,4 @@ var $ = {
   destroy() { /* noop */ },
   IsHTMLDDA() { return {}; },
   source: $SOURCE,
-  file: $FILE,
-  scriptFile: $SCRIPT_FILE,
-  scriptStartMarker: $SCRIPT_START_MARKER,
-  scriptEndMarker: $SCRIPT_END_MARKER,
 };

--- a/runtimes/sm.js
+++ b/runtimes/sm.js
@@ -33,7 +33,13 @@ var $ = {
     this.global[name] = value;
   },
   destroy() { /* noop */ },
-  IsHTMLDDA() { return objectEmulatingUndefined(); },
+  IsHTMLDDA() {
+    /* objectEmulatingUndefined was replaced by createIsHTMLDDA in newer SpiderMonkey builds. */
+    if (typeof createIsHTMLDDA === 'function') {
+      return createIsHTMLDDA();
+    }
+    return objectEmulatingUndefined();
+  },
   source: $SOURCE
 };
 

--- a/test/runify.js
+++ b/test/runify.js
@@ -487,8 +487,8 @@ hosts.forEach(function (record) {
         }
 
         if (type === 'jsc') {
-          hostArguments = '--useWebAssembly=true';
-          source = 'print(typeof WebAssembly === "function");';
+          hostArguments = '--useWebAssembly=false';
+          source = 'print(typeof WebAssembly === "undefined");';
         }
 
         if (type === 'jsshell') {


### PR DESCRIPTION
JSC:
- Switch to the new `createGlobalObject()` and `loadString()` functions. A whole lot of additional code is now no longer needed.
- Update the host arguments test now that WebAssembly is enabled by default.

V8:
- Use `Realm.createAllowCrossRealmAccess()` to allow direct access to global properties from other realms.
- Renamed the variables in `$.createRealm()` to make the code more similar to the other runtimes.
- Always set `$.realm` to the current realm-id to avoid possible differences in `$.evalScript` when called from the initial realm (realm-id = 0) compared to when `$.evalScript` is called from child-realms (realm-id > 0). (In the initial global, `$.realm` wasn't set, so the check in `this.realm ? ...` always evalutes to false, which means when a child-realm calls `initialRealm.evalScript`, the script will always be executed in the current realm, but not in the initial realm.)

SpiderMonkey:
- Test for `createIsHTMLDDA` to support newer SpiderMonkey builds.