### PR TITLE
Handle slow spawn.stdout

### DIFF
--- a/lib/ConsoleAgent.js
+++ b/lib/ConsoleAgent.js
@@ -18,7 +18,27 @@ class ConsoleAgent extends Agent {
   }
 
   createChildProcess(args = []) {
-    return cp.spawn(this.hostPath, this.args.concat(args));
+    return new Promise((resolve, reject) => {
+      const child = cp.spawn(this.hostPath, [...this.args, ...args]);
+      if (!child.stdout) {
+        const timeout = setTimeout(() => {
+          clearInterval(interval);
+          reject('The child_process.spawn timed out.');
+        }, 10000);
+
+        // Wait until stdout is ready
+        const interval = setInterval(() => {
+          if (child.stdout) {
+            clearInterval(interval);
+            clearTimeout(timeout);
+            console.log('timeout cleared.');
+            resolve(child);
+          }
+        }, 300);
+      } else {
+        resolve(child);
+      }
+    });
   }
 
   receiveOut(cp, str) {
@@ -34,7 +54,7 @@ class ConsoleAgent extends Agent {
 
     code = this.compile(code);
     this._cp = writeFile(tempfile, code)
-      .then(_ => this.createChildProcess([tempfile]));
+      .then(() => this.createChildProcess([tempfile]));
 
     return this._cp.then(child => {
       let stdout = '';

--- a/lib/ConsoleAgent.js
+++ b/lib/ConsoleAgent.js
@@ -19,7 +19,7 @@ class ConsoleAgent extends Agent {
 
   createChildProcess(args = []) {
     return new Promise((resolve, reject) => {
-      const child = cp.spawn(this.hostPath, [...this.args, ...args]);
+      const child = cp.spawn(this.hostPath, this.args.concat(args));
       if (!child.stdout) {
         const timeout = setTimeout(() => {
           clearInterval(interval);


### PR DESCRIPTION
In a high demand case I've found times where spawn returned an
unfinished object, without in the returned object.

This patch provides a workaround for this problem, but at the
same time if should probably be fixed directly on spawn itself.
In the meanwhile, offers some compatibility over non up to date
Node versions.