### PR TITLE
#52 DYLD_FRAMEWORK_PATH string match for JSC Agent: removing top level webkit directory string match to avoid casing or rename mismatches

### DIFF
--- a/lib/agents/jsc.js
+++ b/lib/agents/jsc.js
@@ -93,11 +93,11 @@ class JSCAgent extends ConsoleAgent {
     if (DYLD_FRAMEWORK_PATH === undefined) {
       if (isSymlink.sync(this.hostPath)) {
         let linked = fs.readlinkSync(this.hostPath);
-        if (linked.includes('WebKit/WebKitBuild')) {
+        if (linked.includes('/WebKitBuild/')) {
           DYLD_FRAMEWORK_PATH = path.dirname(linked);
         }
       } else {
-        if (this.hostPath.includes('WebKit/WebKitBuild')) {
+        if (this.hostPath.includes('/WebKitBuild/')) {
           DYLD_FRAMEWORK_PATH = path.dirname(this.hostPath);
         }
       }


### PR DESCRIPTION
PR for #52. 