### PR TITLE
Fix invalid d8 runtime

### DIFF
--- a/lib/ConsoleAgent.js
+++ b/lib/ConsoleAgent.js
@@ -81,7 +81,7 @@ class ConsoleAgent extends Agent {
     let runtime = this.constructor.runtime;
     let { options: hostOptions } = this;
 
-    if (runtime && hostOptions.shortName) {
+    if (runtime) {
       let ast = recast.parse(runtime);
 
       recast.visit(ast, {
@@ -91,11 +91,14 @@ class ConsoleAgent extends Agent {
             node.value.comments.length = 0;
           }
 
-          // Replace $ in runtime source
-          if (node.value.type === "Identifier" &&
-              node.value.name === "$") {
-            node.value.name = hostOptions.shortName;
+          if (hostOptions.shortName) {
+            // Replace $ in runtime source
+            if (node.value.type === "Identifier" &&
+                node.value.name === "$") {
+              node.value.name = hostOptions.shortName;
+            }
           }
+
           this.traverse(node);
         }
       });

--- a/lib/ConsoleAgent.js
+++ b/lib/ConsoleAgent.js
@@ -134,6 +134,7 @@ class ConsoleAgent extends Agent {
 
 ConsoleAgent.runtime = `
   /* This is not the agent you're looking for */
+  const name = 'ConsoleAgent';
 `;
 
 module.exports = ConsoleAgent;

--- a/test/consoleagent.js
+++ b/test/consoleagent.js
@@ -66,7 +66,7 @@ describe('ConsoleAgent', function () {
         let async = true;
         let compiled = agent.compile(program, {async});
 
-        assert.equal(compiled, `const name = 'ConsoleAgent';${program}`.replace(/\r?\n/g, ''));
+        assert.equal(compiled, `  const name = 'ConsoleAgent';${program}`.replace(/\r?\n/g, ''));
       });
     });
     it('Removes all linebreaks from runtime code', function() {

--- a/test/consoleagent.js
+++ b/test/consoleagent.js
@@ -66,7 +66,7 @@ describe('ConsoleAgent', function () {
         let async = true;
         let compiled = agent.compile(program, {async});
 
-        assert.equal(compiled, `${ConsoleAgent.runtime}${program}`.replace(/\r?\n/g, ''));
+        assert.equal(compiled, `const name = 'ConsoleAgent';${program}`.replace(/\r?\n/g, ''));
       });
     });
     it('Removes all linebreaks from runtime code', function() {


### PR DESCRIPTION
The combination of #50 and #51 has resulted in the d8 runtime being
invalid because the single-line comments remove all following code when
newlines are removed.

The fix is to always build the AST and remove comments, regardless of
whether the shortName is being replaced.