### PR TITLE
Remove dependency preamble building operations

### DIFF
--- a/lib/ConsoleAgent.js
+++ b/lib/ConsoleAgent.js
@@ -53,7 +53,6 @@ class ConsoleAgent extends Agent {
 
     let isExpectingRawSource = false;
     let hasDependencies = false;
-    let sourcecode;
 
     const sources = [];
     const dependencies = [];
@@ -68,15 +67,6 @@ class ConsoleAgent extends Agent {
       let {attrs, contents, file} = code;
 
       isExpectingRawSource = !!attrs.flags.raw;
-
-      rawSource.clear();
-
-      // When testing code that has the "module" flag,
-      // the raw source of the entry point module is needed
-      // to create a preamble for all of the dependencies.
-      let rawsource = fs.readFileSync(file, 'utf8');
-
-      sourcecode = rawsource.split(/\/\*---[\r\n]+[\S\s]*[\r\n]+---\*\//)[1];
 
       let { phase = '', type = '' } = attrs.negative || {};
       let isEarlySyntaxError = (phase === 'early' || phase === 'parse') && type === 'SyntaxError';
@@ -126,25 +116,23 @@ class ConsoleAgent extends Agent {
 
     // If any dependencies were discovered, there will be
     if (hasDependencies) {
-      // We need to "borrow" the compiled preamble code from the main
-      // test file. This will include the harness and agent runtime sources.
-      let preamble = isExpectingRawSource ? '' : code.slice(0, code.indexOf(sourcecode));
-
       // Prepare dependencies for use:
       //
-      // 1. Load the source and extract the part that is actual JS code
-      // 2. Prepend the preamble to the JS code
-      // 3. Add the prepped source to list of sources that will be written
+      // 1. Make an absolute path for the dependency file.
+      // 2. Get the dependency's source from the rawSource cache
+      // 3. Push the dependency and source into the sources to be written.
       //
       dependencies.forEach(file => {
         let absname = path.join(temppath, file);
-        let rawsource = rawSource.get(path.basename(file));
-        let jspart = rawsource.split(/\/\*---[\r\n]+[\S\s]*[\r\n]+---\*\//)[1];
+        let depsource = rawSource.get(path.basename(file));
 
+        // Sometimes a test file might want to import itself,
+        // which is a valid exercise of the import semantics.
+        // Here we avoid adding the test file more than once.
         if (absname !== tempfile) {
           sources.push([
             absname,
-            `${preamble}\n${jspart ? jspart : rawsource}`
+            depsource
           ]);
         }
       });

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-cls.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-cls.js
@@ -43,5 +43,11 @@ assert.throws(ReferenceError, function() {
   typeof B;
 }, 'binding is created but not initialized');
 
-import { B } from './instn-iee-bndng-cls_FIXTURE.js';
+import { B, results } from './instn-iee-bndng-cls_FIXTURE.js';
 export class A {}
+
+assert.sameValue(results.length, 4);
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-cls_FIXTURE.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-cls_FIXTURE.js
@@ -5,14 +5,17 @@ export { A as B } from './instn-iee-bndng-cls.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
+export const results = [];
+try {
   A;
-});
-assert.sameValue(typeof A, 'undefined');
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
+try {
   B;
-});
-assert.sameValue(typeof B, 'undefined');
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-const.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-const.js
@@ -40,8 +40,14 @@ flags: [module]
 ---*/
 
 assert.throws(ReferenceError, function() {
-  typeof y;
+  typeof B;
 }, 'binding is created but not initialized');
 
-import { y } from './instn-iee-bndng-const_FIXTURE.js';
-export const x = null;
+import { B, results } from './instn-iee-bndng-const_FIXTURE.js';
+export const A = null;
+
+assert.sameValue(results.length, 4);
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-const_FIXTURE.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-const_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { x as y } from './instn-iee-bndng-const.js';
+export { A as B } from './instn-iee-bndng-const.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  x;
-});
-assert.sameValue(typeof x, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  y;
-});
-assert.sameValue(typeof y, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-fun.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-fun.js
@@ -40,16 +40,22 @@ flags: [module]
 ---*/
 
 assert.sameValue(
-  f2(),
+  B(),
   77,
   'binding is initialized to function value prior to module evaluation'
 );
 
 assert.throws(TypeError, function() {
-  f2 = null;
+  B = null;
 }, 'binding rejects assignment');
 
-assert.sameValue(f2(), 77, 'binding value is immutable');
+assert.sameValue(B(), 77, 'binding value is immutable');
 
-import { f2 } from './instn-iee-bndng-fun_FIXTURE.js';
-export function f() { return 77; }
+import { B, results } from './instn-iee-bndng-fun_FIXTURE.js';
+export function A() { return 77; }
+
+assert.sameValue(results.length, 4);
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-fun_FIXTURE.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-fun_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { f as f2 } from './instn-iee-bndng-fun.js';
+export { A as B } from './instn-iee-bndng-fun.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  f;
-});
-assert.sameValue(typeof f, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  f2;
-});
-assert.sameValue(typeof f2, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-gen.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-gen.js
@@ -42,16 +42,22 @@ features: [generators]
 ---*/
 
 assert.sameValue(
-  g2().next().value,
+  B().next().value,
   455,
   'binding is initialized to function value prior to module evaluation'
 );
 
 assert.throws(TypeError, function() {
-  g2 = null;
+  B = null;
 });
 
-assert.sameValue(g2().next().value, 455, 'binding value is immutable');
+assert.sameValue(B().next().value, 455, 'binding value is immutable');
 
-import { g2 } from './instn-iee-bndng-gen_FIXTURE.js';
-export function* g () { return 455; }
+import { B, results } from './instn-iee-bndng-gen_FIXTURE.js';
+export function* A () { return 455; }
+
+assert.sameValue(results.length, 4);
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-gen_FIXTURE.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-gen_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { g as g2 } from './instn-iee-bndng-gen.js';
+export { A as B } from './instn-iee-bndng-gen.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  g;
-});
-assert.sameValue(typeof g, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  g2;
-});
-assert.sameValue(typeof g2, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-let.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-let.js
@@ -40,8 +40,14 @@ flags: [module]
 ---*/
 
 assert.throws(ReferenceError, function() {
-  typeof y;
+  typeof B;
 }, 'binding is created but not initialized');
 
-import { y } from './instn-iee-bndng-let_FIXTURE.js';
-export let x;
+import { B, results } from './instn-iee-bndng-let_FIXTURE.js';
+export let A;
+
+assert.sameValue(results.length, 4);
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-let_FIXTURE.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-let_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { x as y } from './instn-iee-bndng-let.js';
+export { A as B } from './instn-iee-bndng-let.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  x;
-});
-assert.sameValue(typeof x, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  y;
-});
-assert.sameValue(typeof y, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-var.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-var.js
@@ -40,16 +40,23 @@ flags: [module]
 ---*/
 
 assert.sameValue(
-  y,
+  B,
   undefined,
   'binding is initialized to `undefined` prior to module evaulation'
 );
 
 assert.throws(TypeError, function() {
-  y = null;
+  B = null;
 }, 'binding rejects assignment');
 
-assert.sameValue(y, undefined, 'binding value is immutable');
+assert.sameValue(B, undefined, 'binding value is immutable');
 
-import { y } from './instn-iee-bndng-var_FIXTURE.js';
-export var x = 99;
+import { B, results } from './instn-iee-bndng-var_FIXTURE.js';
+export var A = 99;
+
+assert.sameValue(results.length, 4);
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');
+

--- a/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-var_FIXTURE.js
+++ b/test/fixtures/fake-test262/test/language/module-code/instn-iee-bndng-var_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { x as y } from './instn-iee-bndng-var.js';
+export { A as B } from './instn-iee-bndng-var.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  x;
-});
-assert.sameValue(typeof x, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  y;
-});
-assert.sameValue(typeof y, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}


### PR DESCRIPTION
This code only existed to allow 6 Test262 tests to run. INTERPRETING.md now disallows the use of "Test262-Defined Bindings" and "Host-Defined Functions" inside _FIXTURE.js files.