### PR TITLE
ConsoleAgent: Log unexpected signals to stderr

### DIFF
--- a/lib/ConsoleAgent.js
+++ b/lib/ConsoleAgent.js
@@ -149,7 +149,10 @@ class ConsoleAgent extends Agent {
       child.stderr.on('data', str => { stderr += str; });
 
       return new Promise(resolve => {
-        child.on('close', () => {
+        child.on('close', (code, signal) => {
+          if (signal && signal != "SIGKILL") {
+            stderr += "Error: Received unexpected signal: " + signal;
+          }
           resolve({stdout, stderr});
         });
       });


### PR DESCRIPTION
Hi,

Currently, eshost (and eshost-cli) doesn't log unexpected signals (e.g., SIGSEGV) from the child process. As some of the supported JS engines are still in development, this can suppress errors when the engine seg-faults. At this time, seg-faulting test-cases have no output on affected engines and appear to exit successfully.

I noticed SIGKILL was used internally for process control, so my patch captures all signals other than SIGKILL.

This PR should also provide better support for eshost-cli e.g., https://github.com/bterlson/eshost-cli/issues/55 

Thank you!