### PR TITLE
Use only pre-es6 syntax in the `node` runtime

### DIFF
--- a/lib/agents/node.js
+++ b/lib/agents/node.js
@@ -38,11 +38,11 @@ class NodeAgent extends ConsoleAgent {
       Function("return this;")().require = require;
       var vm = require("vm");
       var eshostContext = vm.createContext({
-        setTimeout,
-        require,
-        console,
-        print(...args) {
-          console.log(...args);
+        setTimeout: setTimeout,
+        require: require,
+        console: console,
+        print: function print() {
+          console.log.apply(console, arguments);
         }
       });
       vm.runInESHostContext = function(code, options) {

--- a/runtimes/node.js
+++ b/runtimes/node.js
@@ -1,13 +1,13 @@
-function print(...args) {
-  console.log(...args);
+function print() {
+  console.log.apply(console, arguments);
 }
 var vm = require('vm');
 var $262 = {
   global: Function('return this')(),
-  gc() {
+  gc: function() {
     return gc();
   },
-  createRealm(options) {
+  createRealm: function createRealm(options) {
     options = options || {};
     options.globals = options.globals || {};
 
@@ -32,7 +32,7 @@ var $262 = {
     };
     return context.$262;
   },
-  evalScript(code) {
+  evalScript: function evalScript(code) {
     try {
       if (this.context) {
         vm.runInContext(code, this.context, {displayErrors: false});
@@ -45,14 +45,14 @@ var $262 = {
       return { type: 'throw', value: e };
     }
   },
-  getGlobal(name) {
+  getGlobal: function getGlobal(name) {
     return this.global[name];
   },
-  setGlobal(name, value) {
+  setGlobal: function setGlobal(name, value) {
     this.global[name] = value;
   },
-  destroy() { /* noop */ },
-  IsHTMLDDA() { return {}; },
+  destroy: function destroy() { /* noop */ },
+  IsHTMLDDA: function IsHTMLDDA() { return {}; },
   source: $SOURCE
 };
 


### PR DESCRIPTION
To allow the runtime to be used with very old versions of node that predate es6 support (like `node 0.10`). It used to be like this before https://github.com/bterlson/eshost/pull/41 and https://github.com/bterlson/eshost/pull/28 which were by and large unrelated to _explicitly_ dropping support for older hosts in the test runtime, seems like; so it'd be nice to still support them, IMO.