### PR TITLE
Extend GraalJS functionality

### DIFF
--- a/lib/agents/graaljs.js
+++ b/lib/agents/graaljs.js
@@ -3,6 +3,9 @@
 const fs = require('fs');
 const runtimePath = require('../runtime-path');
 const ConsoleAgent = require('../ConsoleAgent');
+const ErrorParser = require('../parse-error.js');
+
+const errorRe = /(.*?): (.+?) (.+)(\n(\s*)at (.+))*/;
 
 class GraalJSAgent extends ConsoleAgent {
   evalScript(code, options = {}) {
@@ -13,11 +16,47 @@ class GraalJSAgent extends ConsoleAgent {
     if (!options.module && this.args[0] === '--module') {
       this.args.shift();
     }
-    this.args.unshift('--js.ecmascript-version=2020');
-    this.args.unshift('--js.intl-402=true');
+
     return super.evalScript(code, options);
   }
+
+  parseError(str) {
+    const match = str.match(errorRe);
+    if(!match) {
+      return null;
+    }
+    const stackStr = match[4] || '';
+
+    let stack;
+    if (stackStr.trim().length > 0) {
+      stack = ErrorParser.parseStack(stackStr);
+    } else {
+      stack = [{
+        source: match[0],
+        fileName: match[1],
+        lineNumber: match[2]
+      }];
+    }
+
+    return {
+      name: match[1],
+      message: match[3],
+      stack: stack,
+    };
+  }
+
+  normalizeResult(result) {
+    const match = result.stdout.match(errorRe);
+
+    if (match) {
+      result.stdout = result.stdout.replace(errorRe, '');
+      result.stderr = match[0];
+    }
+
+    return result;
+  }
 }
+
 GraalJSAgent.runtime = fs.readFileSync(runtimePath.for('graaljs'), 'utf8');
 
 module.exports = GraalJSAgent;

--- a/lib/agents/graaljs.js
+++ b/lib/agents/graaljs.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const fs = require('fs');
+const runtimePath = require('../runtime-path');
+const ConsoleAgent = require('../ConsoleAgent');
+
+const errorRe = /^(.*?):(\d+):(\d+)(?: (\w+):)? (.*)$/m;
+
+class GraalJSAgent extends ConsoleAgent {
+  createChildProcess(args) {
+    args = args || [];
+    args.unshift('--language=es6');
+    return super.createChildProcess(args);
+  }
+
+  parseError(str) {
+    const error = {};
+    const match = str.match(errorRe);
+
+    if (!match) {
+      return null;
+    }
+
+    error.name = match[4] || 'SyntaxError';
+    error.message = match[5];
+
+    error.stack = [{
+      source: match[0],
+      fileName: match[1],
+      lineNumber: match[2],
+      columnNumber: match[3]
+    }];
+
+    return error;
+  }
+}
+GraalJSAgent.runtime = fs.readFileSync(runtimePath.for('graaljs'), 'utf8');
+
+module.exports = GraalJSAgent;

--- a/lib/agents/graaljs.js
+++ b/lib/agents/graaljs.js
@@ -13,6 +13,8 @@ class GraalJSAgent extends ConsoleAgent {
     if (!options.module && this.args[0] === '--module') {
       this.args.shift();
     }
+    this.args.unshift('--js.ecmascript-version=2020');
+    this.args.unshift('--js.intl-402=true');
     return super.evalScript(code, options);
   }
 }

--- a/lib/agents/graaljs.js
+++ b/lib/agents/graaljs.js
@@ -4,34 +4,16 @@ const fs = require('fs');
 const runtimePath = require('../runtime-path');
 const ConsoleAgent = require('../ConsoleAgent');
 
-const errorRe = /^(.*?):(\d+):(\d+)(?: (\w+):)? (.*)$/m;
-
 class GraalJSAgent extends ConsoleAgent {
-  createChildProcess(args) {
-    args = args || [];
-    args.unshift('--language=es6');
-    return super.createChildProcess(args);
-  }
-
-  parseError(str) {
-    const error = {};
-    const match = str.match(errorRe);
-
-    if (!match) {
-      return null;
+  evalScript(code, options = {}) {
+    if (options.module && this.args[0] !== '--module') {
+      this.args.unshift('--module');
     }
 
-    error.name = match[4] || 'SyntaxError';
-    error.message = match[5];
-
-    error.stack = [{
-      source: match[0],
-      fileName: match[1],
-      lineNumber: match[2],
-      columnNumber: match[3]
-    }];
-
-    return error;
+    if (!options.module && this.args[0] === '--module') {
+      this.args.shift();
+    }
+    return super.evalScript(code, options);
   }
 }
 GraalJSAgent.runtime = fs.readFileSync(runtimePath.for('graaljs'), 'utf8');

--- a/lib/supported-hosts.js
+++ b/lib/supported-hosts.js
@@ -26,6 +26,7 @@ const supportedHostsMap = Object.assign({
   // d8: 'd8',
   v8: 'd8',
   // xs: 'xs',
+  graaljs: 'graaljs',
 
   /* Browsers */
   // chrome: 'chrome',

--- a/runtimes/graaljs.js
+++ b/runtimes/graaljs.js
@@ -1,0 +1,54 @@
+var $262 = {
+  global: Function('return this')(),
+  gc() {
+    throw new Test262Error('GC not yet supported.');
+  },
+  createRealm: function(options) {
+    options = options || {};
+    options.globals = options.globals || {};
+
+    var realm = loadWithNewGlobal({ script: 'this', name: 'createRealm' });
+    realm.eval(this.source);
+    realm.$262.source = this.source;
+    realm.$262.destroy = function () {
+      if (options.destroy) {
+        options.destroy();
+      }
+    };
+
+    for(var glob in options.globals) {
+      realm.$262.global[glob] = options.globals[glob];
+    }
+
+    return realm.$262;
+  },
+  evalScript: function(code) {
+    try {
+      load({ script: code, name: 'evalScript' });
+      return { type: 'normal', value: undefined }
+    } catch (e) {
+      return { type: 'throw', value: e }
+    }
+  },
+  getGlobal: function(name) {
+    return this.global[name];
+  },
+  setGlobal: function(name, value) {
+    this.global[name] = value;
+  },
+  destroy: function() { /* noop */ },
+  IsHTMLDDA: function() { return {}; },
+  source: $SOURCE,
+  agent: (function() {
+    function thrower() {
+      throw new Test262Error('Agent not yet supported.');
+    };
+    return {
+      start: thrower,
+      broadcast: thrower,
+      getReport: thrower,
+      sleep: thrower,
+      monotonicNow: thrower,
+    };
+  })(),
+};

--- a/runtimes/graaljs.js
+++ b/runtimes/graaljs.js
@@ -1,5 +1,7 @@
+var es = $262.evalScript;
+var a = $262.agent;
 var $262 = {
-  global: Function('return this')(),
+  global: globalThis,
   gc() {
     throw new Test262Error('GC not yet supported.');
   },
@@ -22,14 +24,6 @@ var $262 = {
 
     return realm.$262;
   },
-  evalScript: function(code) {
-    try {
-      load({ script: code, name: 'evalScript' });
-      return { type: 'normal', value: undefined }
-    } catch (e) {
-      return { type: 'throw', value: e }
-    }
-  },
   getGlobal: function(name) {
     return this.global[name];
   },
@@ -38,17 +32,7 @@ var $262 = {
   },
   destroy: function() { /* noop */ },
   IsHTMLDDA: function() { return {}; },
-  source: $SOURCE,
-  agent: (function() {
-    function thrower() {
-      throw new Test262Error('Agent not yet supported.');
-    };
-    return {
-      start: thrower,
-      broadcast: thrower,
-      getReport: thrower,
-      sleep: thrower,
-      monotonicNow: thrower,
-    };
-  })(),
+  source: $SOURCE
 };
+$262.evalScript = es;
+$262.agent = a;


### PR DESCRIPTION
GraalJS provides the `$262` object with some properties (i.e. `evalScript`, `agent`) behind `--experimental-options --js.test262-mode=true` flags.