### PR TITLE
Update engine262.js

### DIFF
--- a/runtimes/engine262.js
+++ b/runtimes/engine262.js
@@ -5,7 +5,7 @@ var $262 = {
   realm: null,
   global: engine262.global,
   gc() {
-    throw new Test262Error('gc() not yet supported.');
+    return engine262.gc();
   },
   createRealm(options) {
     options = options || {};
@@ -39,7 +39,6 @@ var $262 = {
       return { type: 'throw', value: e };
     }
   },
-
   detachArrayBuffer: engine262.detachArrayBuffer,
   getGlobal(name) {
     return this.global[name];


### PR DESCRIPTION
engine262 exposes both `$` and `$262` so ideally only a few things should need to be patched, instead of copying the entire object, but i'm not entirely sure how i should restructure this for that.