### PR TITLE
Spidermonkey updates

### DIFF
--- a/lib/agents/jsshell.js
+++ b/lib/agents/jsshell.js
@@ -5,7 +5,7 @@ const runtimePath = require('../runtime-path');
 const ConsoleAgent = require('../ConsoleAgent');
 
 const errorRe = /^(.*?)?:(\d+):(\d+)? ([\w\d]+): (.+)?$/m;
-const customErrorRe = /^(?:uncaught exception: |:)([\w\d]+): (.+)$/m;
+const customErrorRe = /^(?:uncaught exception: |:)([\w\d]+): (.+)?$/m;
 
 class JSShell extends ConsoleAgent {
   evalScript(code, options = {}) {

--- a/lib/agents/jsshell.js
+++ b/lib/agents/jsshell.js
@@ -7,6 +7,9 @@ const ConsoleAgent = require('../ConsoleAgent');
 const errorRe = /^(.*?)?:(\d+):(\d+)? ([\w\d]+): (.+)?$/m;
 const customErrorRe = /^(?:uncaught exception: |:)([\w\d]+): (.+)?$/m;
 
+const stackRe = /^([\s\S]*?)\r?\nStack:\r?\n([\s\S]*)$/;
+const stackFrameRe = /^(.*?)?@(.*?):(\d+):(\d+)?$/;
+
 class JSShell extends ConsoleAgent {
   evalScript(code, options = {}) {
     if (options.module && this.args[0] !== '--module') {
@@ -21,6 +24,28 @@ class JSShell extends ConsoleAgent {
   }
 
   parseError(str) {
+    const stack = [];
+    const stackMatch = str.match(stackRe);
+    if (stackMatch) {
+      str = stackMatch[1];
+
+      const stackStr = stackMatch[2];
+      for (const line of stackStr.split(/\r?\n/g)) {
+        const match = line.trim().match(stackFrameRe);
+        if (!match) {
+          continue;
+        }
+
+        stack.push({
+          source: match[0],
+          functionName: match[1],
+          fileName: match[2],
+          lineNumber: match[3],
+          columnNumber: match[4],
+        });
+      }
+    }
+
     const error = {};
     let match = str.match(errorRe);
 
@@ -34,19 +59,22 @@ class JSShell extends ConsoleAgent {
 
       error.name = match[1];
       error.message = match[2];
-      error.stack = [];
+      error.stack = stack;
       return error;
     }
 
     error.name = match[4];
     error.message = match[5];
 
-    error.stack = [{
-      source: match[0],
-      fileName: match[1],
-      lineNumber: match[2],
-      columnNumber: match[3]
-    }];
+    if (stack.length === 0) {
+      stack.push({
+        source: match[0],
+        fileName: match[1],
+        lineNumber: match[2],
+        columnNumber: match[3]
+      });
+    }
+    error.stack = stack;
 
     return error;
   }


### PR DESCRIPTION
11bf59d:
- Adds the upstream changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1473000

9b99cc6:
- Allows that the error message is absent in "uncaught exceptions".
- This ensures `throw new Test262Error()` in test262 is correctly handled.
- For example all tests in <https://test262.report/browse/annexB/language/comments> are currently marked as failing in SpiderMonkey, even though SpiderMonkey actually passes these tests. It's just that `eshost` doesn't correctly parse the error string reported from SpiderMonkey.

505e5c4:
- Improves the error parser to include stack frames.