### PR TITLE
Remove IsHTMLDDA stub for JSC

### DIFF
--- a/runtimes/jsc.js
+++ b/runtimes/jsc.js
@@ -1,7 +1,6 @@
 /* JavaScriptCore exposes a $ & $262 object to its runtime */
 $262.source = $SOURCE;
 $262.destroy = function() {};
-$262.IsHTMLDDA = function() {};
 $262.getGlobal = function(name) {
   return this.global[name];
 };


### PR DESCRIPTION
Real `$262.IsHTMLDDA` was implemented in [r259587](https://trac.webkit.org/changeset/259587).