### PR TITLE
Correct definition of JSC "runtime" object

### DIFF
--- a/runtimes/jsc.js
+++ b/runtimes/jsc.js
@@ -3,7 +3,14 @@ const jsc = globalThis["\x24"];
 const DollarCreateRealm = jsc.createRealm;
 const DollarEvalScript = jsc.evalScript.bind(jsc);
 
-var $262 = Object.assign({}, jsc);
+var $262 = {};
+// Copy "own" properties from the JSC-defined object to the normalized `$262`
+// object. Neither `Object.assign` nor the object "spread" syntax can be used
+// for this task because not all properties on the source object are
+// enumerable.
+Object.getOwnPropertyNames(jsc).forEach(function(name) {
+  $262[name] = jsc[name];
+});
 $262.global = globalThis;
 $262.source = $SOURCE;
 $262.destroy = function() {};

--- a/test/runify.js
+++ b/test/runify.js
@@ -958,5 +958,26 @@ hosts.forEach(function (record) {
         await agent.destroy();
       });
     });
+
+    describe("agent", () => {
+      if (!["jsc", "jsshell", "d8"].includes(type)) {
+        return;
+      }
+
+      const read = async (expression) => {
+        const result = await agent.evalScript(`print(${expression});`);
+        expect(result.error).toBe(null);
+        return result.stdout;
+      };
+
+      it("exposes the complete Test262-defined API", async () => {
+        expect(await read("typeof $262.agent")).toMatch(/^object/);
+        expect(await read("typeof $262.agent.start")).toMatch(/^function/);
+        expect(await read("typeof $262.agent.broadcast")).toMatch(/^function/);
+        expect(await read("typeof $262.agent.getReport")).toMatch(/^function/);
+        expect(await read("typeof $262.agent.sleep")).toMatch(/^function/);
+        expect(await read("typeof $262.agent.monotonicNow")).toMatch(/^function/);
+      });
+    });
   });
 });


### PR DESCRIPTION
A recent commit [1] regressed support for JavaScriptCore by changing the
way the "runtime" object is defined for that engine. Restore the
intended behavior and add an automated test.

[1] 4e9c3ee9b2c8cb1578e5bd9af18a028890b35b4d

---

The CI system is not currently configured to validate this change (or any other change) in JavaScriptCore. See gh-112 for that.

The regression has been observed in results published to test262.report: https://github.com/bocoup/test262-report-issue-tracker/issues/28