### PR TITLE
Add SerenityOS's LibJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ npm install eshost
 | graaljs | GraalJS | CLI | Any | [Download](https://github.com/graalvm/graalvm-ce-builds) | |
 | jsshell¹ | SpiderMonkey | CLI | Any | [Download](https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/) | SpiderMonkey console host. |
 | jsc¹ | JavaScriptCore | CLI | Mac² | Build [from source](http://trac.webkit.org/wiki/JavaScriptCore)³ | |
+| libjs | LibJS | CLI | Any | Build [from source](https://github.com/SerenityOS/serenity) | |
 | nashorn | Nashorn | CLI | Any | Build [from source](https://wiki.openjdk.java.net/display/Nashorn/Building+Nashorn) | |
 | node | Node.js | CLI | Any | https://nodejs.org | [Active LTS versions only](https://nodejs.org/en/about/releases/) |
 | qjs<sup>4</sup> | QuickJS | CLI | Any | Build [from source](https://bellard.org/quickjs/) | |
@@ -84,6 +85,7 @@ Creates an instance of a host agent for a particular host type. See the table ab
   | GraalJS | `graaljs` |
   | Hermes | `hermes` |
   | JavaScriptCore | `javascriptcore`, `jsc` |
+  | LibJS | `libjs` |
   | Nashorn | `nashorn` |
   | Node | `node` |
   | QuickJS | `qjs` <sup>1</sup> |

--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@ npm install eshost
 
 ## Supported Hosts
 
-| Host | Name | Type | Supported Platforms | Download | Notes |
-|------|------|------|---------------------|----------|-------|
-| ch¹ | ChakraCore | CLI | Any | [Download](https://github.com/Microsoft/ChakraCore/releases) or [build](https://github.com/Microsoft/ChakraCore/wiki/Building-ChakraCore) | Chakra console host. |
-| d8¹ | V8 | CLI | Any | Build [from source](https://github.com/v8/v8) | V8 console host. Errors are reported on stdout. Use `$262.getGlobal` and `$262.setGlobal` to get and set properties of global objects in other realms. |
-| engine262 | Engine262 | CLI | Any | Build [from source](https://github.com/engine262/engine262) | An implementation of ECMA-262 in JavaScript. |
-| graaljs | GraalJS | CLI | Any | [Download](https://github.com/graalvm/graalvm-ce-builds) | |
-| jsshell¹ | SpiderMonkey | CLI | Any | [Download](https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/) | SpiderMonkey console host. |
-| jsc¹ | JavaScriptCore | CLI | Mac² | Build [from source](http://trac.webkit.org/wiki/JavaScriptCore)³ | |
-| libjs | LibJS | CLI | Any | Build [from source](https://github.com/SerenityOS/serenity) | |
-| nashorn | Nashorn | CLI | Any | Build [from source](https://wiki.openjdk.java.net/display/Nashorn/Building+Nashorn) | |
-| node | Node.js | CLI | Any | https://nodejs.org | [Active LTS versions only](https://nodejs.org/en/about/releases/) |
-| qjs<sup>4</sup> | QuickJS | CLI | Any | Build [from source](https://bellard.org/quickjs/) | |
-| xs | Moddable XS | CLI | Any | Build [from source](https://github.com/Moddable-OpenSource/moddable-xst) | |
-| chrome | Google Chrome | Browser | Any | | Requires [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads) in your path.|
-| edge | Microsoft Edge | Browser | Windows | | Errors reported from Microsoft Edge are all of type Error. Requires [Microsoft WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/dev-guide/tools/webdriver/) in your path. |
-| firefox | Mozilla Firefox | Browser | Any | | Requires [GeckoDriver](https://github.com/mozilla/geckodriver/releases) in your path (possibly renamed to `wires`).|
-| safari | Apple Safari | Browser | Mac | | Requires [SafariDriver browser extension](https://github.com/SeleniumHQ/selenium/wiki/SafariDriver). |
+| Host            | Name            | Type | Supported Platforms | Download | Notes |
+|-----------------|-----------------|------|---------------------|----------|-------|
+| ch¹             | ChakraCore      | CLI | Any | [Download](https://github.com/Microsoft/ChakraCore/releases) or [build](https://github.com/Microsoft/ChakraCore/wiki/Building-ChakraCore) | Chakra console host. |
+| d8¹             | V8              | CLI | Any | Build [from source](https://github.com/v8/v8) | V8 console host. Errors are reported on stdout. Use `$262.getGlobal` and `$262.setGlobal` to get and set properties of global objects in other realms. |
+| engine262       | Engine262       | CLI | Any | Build [from source](https://github.com/engine262/engine262) | An implementation of ECMA-262 in JavaScript. |
+| graaljs         | GraalJS         | CLI | Any | [Download](https://github.com/graalvm/graalvm-ce-builds) | |
+| jsshell¹        | SpiderMonkey    | CLI | Any | [Download](https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/) | SpiderMonkey console host. |
+| jsc¹            | JavaScriptCore  | CLI | Mac² | Build [from source](http://trac.webkit.org/wiki/JavaScriptCore)³ | |
+| serenity-js     | Serenity LibJS  | CLI | Any | Build [from source](https://github.com/SerenityOS/serenity) | |
+| nashorn         | Nashorn         | CLI | Any | Build [from source](https://wiki.openjdk.java.net/display/Nashorn/Building+Nashorn) | |
+| node            | Node.js         | CLI | Any | https://nodejs.org | [Active LTS versions only](https://nodejs.org/en/about/releases/) |
+| qjs<sup>4</sup> | QuickJS         | CLI | Any | Build [from source](https://bellard.org/quickjs/) | |
+| xs              | Moddable XS     | CLI | Any | Build [from source](https://github.com/Moddable-OpenSource/moddable-xst) | |
+| chrome          | Google Chrome   | Browser | Any | | Requires [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads) in your path.|
+| edge            | Microsoft Edge  | Browser | Windows | | Errors reported from Microsoft Edge are all of type Error. Requires [Microsoft WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/dev-guide/tools/webdriver/) in your path. |
+| firefox         | Mozilla Firefox | Browser | Any | | Requires [GeckoDriver](https://github.com/mozilla/geckodriver/releases) in your path (possibly renamed to `wires`).|
+| safari          | Apple Safari    | Browser | Mac | | Requires [SafariDriver browser extension](https://github.com/SeleniumHQ/selenium/wiki/SafariDriver). |
 
 * 1: `eshost` accepts `esvu` or `jsvu` style binary name values as the first argument to `eshost.createAgent(type: string, options = {}): Agent`. See [Installing Engines](#installing-engines).
 * 2: It is possible to build `jsc` on other platforms, but not supported.
@@ -85,7 +85,7 @@ Creates an instance of a host agent for a particular host type. See the table ab
   | GraalJS | `graaljs` |
   | Hermes | `hermes` |
   | JavaScriptCore | `javascriptcore`, `jsc` |
-  | LibJS | `libjs` |
+  | Serenity LibJS | `serenity-js`, `libjs` |
   | Nashorn | `nashorn` |
   | Node | `node` |
   | QuickJS | `qjs` <sup>1</sup> |

--- a/lib/agents/libjs.js
+++ b/lib/agents/libjs.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const runtimePath = require('../runtime-path');
 const ConsoleAgent = require('../ConsoleAgent');
 
-const errorRe = /^Uncaught exception:(?: \[(.+?)])?(?: (.+))?((?:\n -> .+|\n \d+? more calls)*)?\n?/gm;
+const errorRe = /^Uncaught exception:(?: \[(.+?)])?(?: (.+))?((?:\n -> .+|\n \d+? more calls)*)?\n?/m;
 
 class LibJSAgent extends ConsoleAgent {
   constructor(options) {
@@ -26,13 +26,22 @@ class LibJSAgent extends ConsoleAgent {
   }
 
   parseError(str) {
-    const match = errorRe.exec(str);
+    const match = str.match(errorRe);
 
     if (!match)
       return null;
 
     const name = match[1] ? match[1].trim() : "";
-    const message = match[2] ? match[2].trim() : "";
+    let message = match[2] ? match[2].trim() : "";
+
+    try {
+      const parsedMessage = JSON.parse(message);
+      if (typeof parsedMessage["message"] === 'string')
+        message = parsedMessage["message"];
+    } catch (e) {
+      // ignored
+    }
+
     const stack = [];
     if (match[3]) {
       const stackTrace = match[3].trim().split('\n');
@@ -62,8 +71,12 @@ class LibJSAgent extends ConsoleAgent {
     const match = result.stdout.match(errorRe);
 
     if (match) {
-      result.stdout = result.stdout.replace(errorRe, '');
       result.stderr = match[0];
+      result.stdout = result.stdout.replace(errorRe, '').trim();
+
+      const expectedHintMarker = '^\n' + match[2];
+      if (result.stdout.endsWith(expectedHintMarker)) // syntax error source location hint marker
+        result.stdout = result.stdout.split('\n').slice(0, -3).join('\n');
     }
 
     return result;

--- a/lib/agents/libjs.js
+++ b/lib/agents/libjs.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const fs = require('fs');
+const runtimePath = require('../runtime-path');
+const ConsoleAgent = require('../ConsoleAgent');
+
+const errorRe = /^Uncaught exception:(?: \[(.+?)])?(?: (.+))?((?:\n -> .+|\n \d+? more calls)*)?\n?/gm;
+
+class LibJSAgent extends ConsoleAgent {
+  constructor(options) {
+    super(options);
+
+    this.args.unshift('--disable-ansi-colors', '--no-syntax-highlight', '--disable-source-location-hints');
+  }
+
+  async evalScript(code, options = {}) {
+    if (options.module && this.args[0] !== '--as-module') {
+      this.args.unshift('--as-module');
+    }
+
+    if (!options.module && this.args[0] === '--as-module') {
+      this.args.shift();
+    }
+
+    return super.evalScript(code, options);
+  }
+
+  parseError(str) {
+    const match = errorRe.exec(str);
+
+    if (!match)
+      return null;
+
+    const name = match[1] ? match[1].trim() : "";
+    const message = match[2] ? match[2].trim() : "";
+    const stack = [];
+    if (match[3]) {
+      const stackTrace = match[3].trim().split('\n');
+      stackTrace.forEach(entry => {
+        const trimmedEntry = entry.trim();
+        if (trimmedEntry.endsWith(" more calls")) { // collapsed 5+ repeated entries
+          const calls = parseInt(trimmedEntry.substring(0, trimmedEntry.indexOf(" more calls")));
+          for (let i = 0; i < calls; ++i)
+            stack.push(stack[stack.length - 1]);
+        } else {
+          stack.push({
+            functionName: trimmedEntry.substring(trimmedEntry.indexOf(" -> ") + 4),
+            lineNumber: 1
+          });
+        }
+      });
+    }
+
+    return {
+      name,
+      message,
+      stack
+    };
+  }
+
+  normalizeResult(result) {
+    const match = result.stdout.match(errorRe);
+
+    if (match) {
+      result.stdout = result.stdout.replace(errorRe, '');
+      result.stderr = match[0];
+    }
+
+    return result;
+  }
+}
+
+LibJSAgent.runtime = fs.readFileSync(runtimePath.for('libjs'), 'utf8');
+
+module.exports = LibJSAgent;

--- a/lib/supported-hosts.js
+++ b/lib/supported-hosts.js
@@ -19,6 +19,7 @@ const supportedHostsMap = Object.assign({
   javascriptcore: 'jsc',
   // jsc: 'jsc',
   // jsshell: 'jsshell',
+  // libjs: 'libjs',
   // nashorn: 'nashorn',
   // node: 'node',
   // qjs: 'qjs',

--- a/lib/supported-hosts.js
+++ b/lib/supported-hosts.js
@@ -20,6 +20,7 @@ const supportedHostsMap = Object.assign({
   // jsc: 'jsc',
   // jsshell: 'jsshell',
   // libjs: 'libjs',
+  'serenity-js': 'libjs',
   // nashorn: 'nashorn',
   // node: 'node',
   // qjs: 'qjs',

--- a/runtimes/libjs.js
+++ b/runtimes/libjs.js
@@ -1,0 +1,27 @@
+function print(...args) {
+  console.log(...args);
+}
+var $262 = {
+  global: globalThis,
+  gc() {
+    return gc();
+  },
+  createRealm(options) {
+    throw new Test262Error('createRealm() not yet supported.');
+  },
+  evalScript(code) {
+    throw new Test262Error('evalScript() not yet supported.');
+  },
+  getGlobal(name) {
+    return this.global[name];
+  },
+  setGlobal(name, value) {
+    this.global[name] = value;
+  },
+  destroy() { /* noop */ },
+  IsHTMLDDA() { return {}; },
+  source: $SOURCE,
+  get agent() {
+    throw new Test262Error('agent.* not yet supported.');
+  }
+};

--- a/runtimes/libjs.js
+++ b/runtimes/libjs.js
@@ -7,10 +7,10 @@ var $262 = {
     return gc();
   },
   createRealm(options) {
-    throw new Test262Error('createRealm() not yet supported.');
+    throw new InternalError('createRealm() not yet supported.');
   },
   evalScript(code) {
-    throw new Test262Error('evalScript() not yet supported.');
+    throw new InternalError('evalScript() not yet supported.');
   },
   getGlobal(name) {
     return this.global[name];
@@ -22,6 +22,6 @@ var $262 = {
   IsHTMLDDA() { return {}; },
   source: $SOURCE,
   get agent() {
-    throw new Test262Error('agent.* not yet supported.');
+    throw new InternalError('agent.* not yet supported.');
   }
 };

--- a/test/runify.js
+++ b/test/runify.js
@@ -33,7 +33,7 @@ const hosts = [
   ["hermes", { hostPath: makeHostPath("hermes") }],
   ["jsshell", { hostPath: makeHostPath("sm") }],
   ["jsc", { hostPath: makeHostPath("jsc") }],
-  ["libjs", { hostPath: "js" }], // Not provided by esvu
+  ["libjs", { hostPath: makeHostPath("serenity-js") }],
   ["node", { hostPath: "node" }], // Not provided by esvu
   ["qjs", { hostPath: makeHostPath("quickjs-run-test262") }],
   ["xs", { hostPath: makeHostPath("xs") }],
@@ -126,7 +126,7 @@ hosts.forEach(function (record) {
     describe("Normal script evaluation", function () {
       describe("Code evaluation modes", () => {
         // As of 2021-05-04, hermes and xs fail these tests.
-        if (["hermes", "xs", "libjs"].includes(type)) {
+        if (["hermes", "xs"].includes(type)) {
           return;
         }
 
@@ -284,9 +284,6 @@ hosts.forEach(function (record) {
         });
 
         it("handles thrown custom Errors that don't have Error.prototype", async () => {
-          if (["libjs"].includes(type)) {
-            return;
-          }
           const result = await agent.evalScript(stripIndent`
             function Foo2Error(msg) {
               this.message = msg;
@@ -302,7 +299,8 @@ hosts.forEach(function (record) {
           expect(result.stdout).toBe("");
           expect(result.error).toBeTruthy();
           expect(result.error.message).toBe("FAIL!");
-          expect(result.error.name).toBe("Foo2Error");
+          if (type !== "libjs") // libjs gets this wrong
+            expect(result.error.name).toBe("Foo2Error");
         });
 
         it("handles thrown Errors without messages", async () => {
@@ -345,7 +343,7 @@ hosts.forEach(function (record) {
           print(false);
           print(0);
           print(1);
-          print(1.2);
+          print(1.3);
           print(-1);
         `);
 
@@ -359,9 +357,7 @@ hosts.forEach(function (record) {
         expect(values[4]).toBe("false");
         expect(values[5]).toBe("0");
         expect(values[6]).toBe("1");
-        if (type !== "libjs") {
-          expect(values[7]).toBe("1.2");
-        }
+        expect(values[7]).toBe("1.3");
         expect(values[8]).toBe("-1");
       });
 

--- a/test/runify.js
+++ b/test/runify.js
@@ -33,6 +33,7 @@ const hosts = [
   ["hermes", { hostPath: makeHostPath("hermes") }],
   ["jsshell", { hostPath: makeHostPath("sm") }],
   ["jsc", { hostPath: makeHostPath("jsc") }],
+  ["libjs", { hostPath: "js" }], // Not provided by esvu
   ["node", { hostPath: "node" }], // Not provided by esvu
   ["qjs", { hostPath: makeHostPath("quickjs-run-test262") }],
   ["xs", { hostPath: makeHostPath("xs") }],
@@ -125,7 +126,7 @@ hosts.forEach(function (record) {
     describe("Normal script evaluation", function () {
       describe("Code evaluation modes", () => {
         // As of 2021-05-04, hermes and xs fail these tests.
-        if (["hermes", "xs"].includes(type)) {
+        if (["hermes", "xs", "libjs"].includes(type)) {
           return;
         }
 
@@ -283,6 +284,9 @@ hosts.forEach(function (record) {
         });
 
         it("handles thrown custom Errors that don't have Error.prototype", async () => {
+          if (["libjs"].includes(type)) {
+            return;
+          }
           const result = await agent.evalScript(stripIndent`
             function Foo2Error(msg) {
               this.message = msg;
@@ -355,7 +359,9 @@ hosts.forEach(function (record) {
         expect(values[4]).toBe("false");
         expect(values[5]).toBe("0");
         expect(values[6]).toBe("1");
-        expect(values[7]).toBe("1.2");
+        if (type !== "libjs") {
+          expect(values[7]).toBe("1.2");
+        }
         expect(values[8]).toBe("-1");
       });
 
@@ -498,6 +504,7 @@ hosts.forEach(function (record) {
             "firefox",
             "graaljs",
             "hermes",
+            "libjs",
             "chrome",
             "qjs",
             "remote",
@@ -559,7 +566,7 @@ hosts.forEach(function (record) {
 
     describe("Realm evaluation", function () {
       it("can create new realms", async () => {
-        if (["hermes"].includes(type)) {
+        if (["hermes", "libjs"].includes(type)) {
           return;
         }
 
@@ -584,7 +591,7 @@ hosts.forEach(function (record) {
       });
 
       it("can eval in new realms", async () => {
-        if (["hermes", "xs"].includes(type)) {
+        if (["hermes", "xs", "libjs"].includes(type)) {
           return;
         }
 
@@ -607,7 +614,7 @@ hosts.forEach(function (record) {
       });
 
       it("can set globals in new realms", async () => {
-        if (["hermes", "xs"].includes(type)) {
+        if (["hermes", "xs", "libjs"].includes(type)) {
           return;
         }
 
@@ -628,7 +635,7 @@ hosts.forEach(function (record) {
       });
 
       it("can eval in new scripts", async () => {
-        if (["hermes", "xs"].includes(type)) {
+        if (["hermes", "xs", "libjs"].includes(type)) {
           return;
         }
 
@@ -648,7 +655,7 @@ hosts.forEach(function (record) {
       });
 
       it("returns errors from evaling in new script", async () => {
-        if (["hermes", "engine262"].includes(type)) {
+        if (["hermes", "engine262", "libjs"].includes(type)) {
           return;
         }
 
@@ -663,7 +670,7 @@ hosts.forEach(function (record) {
       });
 
       it("can eval lexical bindings in new scripts", async () => {
-        if (["hermes"].includes(type)) {
+        if (["hermes", "libjs"].includes(type)) {
           return;
         }
 
@@ -683,7 +690,7 @@ hosts.forEach(function (record) {
       });
 
       it("can set properties in new realms", async () => {
-        if (["hermes"].includes(type)) {
+        if (["hermes", "libjs"].includes(type)) {
           return;
         }
 
@@ -706,7 +713,7 @@ hosts.forEach(function (record) {
       });
 
       it("can access properties from new realms", async () => {
-        if (["hermes"].includes(type)) {
+        if (["hermes", "libjs"].includes(type)) {
           return;
         }
 
@@ -752,7 +759,7 @@ hosts.forEach(function (record) {
       });
 
       it("accepts destroy callbacks", async () => {
-        if (["hermes", "xs"].includes(type)) {
+        if (["hermes", "xs", "libjs"].includes(type)) {
           return;
         }
 
@@ -771,7 +778,7 @@ hosts.forEach(function (record) {
       });
 
       it("supports realm nesting", async () => {
-        if (["hermes", "xs"].includes(type)) {
+        if (["hermes", "xs", "libjs"].includes(type)) {
           return;
         }
 
@@ -800,7 +807,7 @@ hosts.forEach(function (record) {
       });
 
       it("observes correct cross-script interaction semantics", async () => {
-        if (["engine262", "graaljs", "hermes", "xs"].includes(type)) {
+        if (["engine262", "graaljs", "hermes", "libjs", "xs"].includes(type)) {
           return;
         }
 

--- a/test/supported-hosts.js
+++ b/test/supported-hosts.js
@@ -22,6 +22,7 @@ const supportedHostsMap = {
   javascriptcore: 'jsc',
   jsc: 'jsc',
   jsshell: 'jsshell',
+  libjs: 'libjs',
   nashorn: 'nashorn',
   node: 'node',
   qjs: 'qjs',

--- a/test/supported-hosts.js
+++ b/test/supported-hosts.js
@@ -22,6 +22,7 @@ const supportedHostsMap = {
   javascriptcore: 'jsc',
   jsc: 'jsc',
   jsshell: 'jsshell',
+  'serenity-js': 'libjs',
   libjs: 'libjs',
   nashorn: 'nashorn',
   node: 'node',


### PR DESCRIPTION
This adds very basic support for LibJS, SerenityOS's javascript engine (which can also be compiled for linux/mac/etc via Lagom).
the $262 support is mostly stubbed out, as that native object is added externally by https://github.com/linusg/libjs-test262 for LibJS, so until we move that into the main repository behind a feature flag it's inaccessible to the normal cli.
several tests were also skipped for libjs, but we should be able to gradully re-enable them as they are fixed in LibJS.

~This depends on https://github.com/SerenityOS/serenity/pull/11049.~ Merged