### PR TITLE
d8: Remove experimental notice from stderr

### DIFF
--- a/lib/agents/d8.js
+++ b/lib/agents/d8.js
@@ -49,7 +49,9 @@ class D8Agent extends ConsoleAgent {
   }
 
   normalizeResult(result) {
-    result.stderr = result.stderr.replace(experimentalNotice, '');
+    if (result.stderr.startsWith(experimentalNotice)) {
+      result.stderr = result.stderr.slice(experimentalNotice.length);
+    }
 
     const match = result.stdout.match(errorRe);
 

--- a/lib/agents/d8.js
+++ b/lib/agents/d8.js
@@ -5,6 +5,7 @@ const runtimePath = require('../runtime-path');
 const ConsoleAgent = require('../ConsoleAgent');
 const ErrorParser = require('../parse-error.js');
 
+const experimentalNotice = 'V8 is running with experimental features enabled. Stability and security will suffer.\n';
 const errorRe = /(.*?):(\d+): (([\w\d]+)(?:: (.*))?)[\w\W]*(\3((:?\s+at.*\r?\n)*)(\r?\n)+)?$/;
 
 class D8Agent extends ConsoleAgent {
@@ -48,6 +49,8 @@ class D8Agent extends ConsoleAgent {
   }
 
   normalizeResult(result) {
+    result.stderr = result.stderr.replace(experimentalNotice, '');
+
     const match = result.stdout.match(errorRe);
 
     if (match) {


### PR DESCRIPTION
If you invoke `d8` with any `--harmony` flags, it prints a warning to stderr that you are using experimental technologies. Remove this warning from the captured stderr, because it's just noise - if you are running `d8` with a `--harmony` flag via `eshost`, you probably know what you are doing.

Additionally, non-empty stderr makes test262harness think the test has failed, so it's currently impossible to run test262 tests for a `--harmony` feature.