### PR TITLE
Make IsHTMLDDA an optional property

### DIFF
--- a/runtimes/browser.js
+++ b/runtimes/browser.js
@@ -85,9 +85,7 @@
     destroy() {
       $262.socket.emit("destroy");
     },
-    IsHTMLDDA() {
-      return document.all;
-    },
+    IsHTMLDDA: document.all,
     source: $SOURCE,
   });
 

--- a/runtimes/d8.js
+++ b/runtimes/d8.js
@@ -40,9 +40,7 @@ var $262 = {
   destroy() {
     /* noop */
   },
-  IsHTMLDDA() {
-    return {};
-  },
+  /* No IsHTMLDDA */
   source: $SOURCE,
   realm: Realm.current(),
   detachArrayBuffer(buffer) {

--- a/runtimes/graaljs.js
+++ b/runtimes/graaljs.js
@@ -19,9 +19,7 @@ $262.setGlobal = function (name, value) {
 $262.destroy = function () {
   /* noop */
 };
-$262.IsHTMLDDA = function () {
-  return {};
-};
+/* No IsHTMLDDA */
 $262.source = $SOURCE;
 
 $262.evalScript = function (code) {

--- a/runtimes/hermes.js
+++ b/runtimes/hermes.js
@@ -18,9 +18,7 @@ var $262 = {
   destroy() {
     /* noop */
   },
-  IsHTMLDDA() {
-    return {};
-  },
+  /* No IsHTMLDDA */
   source: $SOURCE,
   get agent() {
     throw new Test262Error("agent.* not yet supported.");

--- a/runtimes/jsc.js
+++ b/runtimes/jsc.js
@@ -49,8 +49,4 @@ $262.createRealm = function (options = {}) {
   return realm;
 };
 
-if (!$262.IsHTMLDDA) {
-  $262.IsHTMLDDA = function () {
-    return {};
-  };
-}
+/* No IsHTMLDDA */

--- a/runtimes/jsshell.js
+++ b/runtimes/jsshell.js
@@ -38,7 +38,7 @@ var $262 = {
   destroy() {
     /* noop */
   },
-  IsHTMLDDA() {
+  get IsHTMLDDA() {
     /* objectEmulatingUndefined was replaced by createIsHTMLDDA in newer SpiderMonkey builds. */
     if (typeof createIsHTMLDDA === "function") {
       return createIsHTMLDDA();

--- a/runtimes/libjs.js
+++ b/runtimes/libjs.js
@@ -21,9 +21,7 @@ var $262 = {
   destroy() {
     /* noop */
   },
-  IsHTMLDDA() {
-    return {};
-  },
+  /* No IsHTMLDDA */
   source: $SOURCE,
   get agent() {
     throw new InternalError("agent.* not yet supported.");

--- a/runtimes/nashorn.js
+++ b/runtimes/nashorn.js
@@ -39,9 +39,7 @@ var $262 = {
   destroy: function () {
     /* noop */
   },
-  IsHTMLDDA: function () {
-    return {};
-  },
+  /* No IsHTMLDDA */
   source: $SOURCE,
   agent: (function () {
     function thrower() {

--- a/runtimes/node.js
+++ b/runtimes/node.js
@@ -55,8 +55,6 @@ var $262 = {
   destroy() {
     /* noop */
   },
-  IsHTMLDDA() {
-    return {};
-  },
+  /* No IsHTMLDDA */
   source: $SOURCE,
 };

--- a/runtimes/xs.js
+++ b/runtimes/xs.js
@@ -37,7 +37,7 @@ if (!$262) {
     })(),
   };
 }
-$262.IsHTMLDDA = function () {};
+/* No IsHTMLDDA */
 $262.destroy = function () {};
 $262.getGlobal = function (name) {
   return this.global[name];

--- a/test/runify.js
+++ b/test/runify.js
@@ -923,9 +923,25 @@ hosts.forEach(function (record) {
       }
       it("has a default IsHTMLDDA", async () => {
         const agent = await eshost.createAgent(type, options);
-        const result = await agent.evalScript("print(typeof $262.IsHTMLDDA);");
+        const result = await agent.evalScript(stripIndent`
+          if (!("IsHTMLDDA" in $262)) {
+            print("absent");
+          } else {
+            const IsHTMLDDA = $262.IsHTMLDDA;
+            print("present");
+            print(typeof IsHTMLDDA === "undefined");
+            print(IsHTMLDDA == null);
+            print(IsHTMLDDA !== undefined && IsHTMLDDA !== null);
+            print(!IsHTMLDDA);
+          }
+        `);
         expect(result.error === null).toBeTruthy();
-        expect(result.stdout.indexOf("function")).toBe(0);
+        const lines = result.stdout.trim().split(/\r?\n/);
+        if (lines[0] === "present") {
+          expect(lines).toEqual(["present", "true", "true", "true", "true"]);
+        } else {
+          expect(lines).toEqual(["absent"]);
+        }
 
         await agent.stop();
         await agent.destroy();


### PR DESCRIPTION
Matches test262 semantics: https://github.com/tc39/test262/blob/main/INTERPRETING.md

We'll need to audit the `/* No IsHTMLDDA */` comments and see which runtimes provide this, for now I only ported the ones that already existed.