### PR TITLE
Remove $262.getGlobal() and $262.setGlobal()

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install eshost
 | Host            | Name            | Type    | Supported Platforms | Download                                                                            | Notes                                                                                                                                                                                                           |
 | --------------- | --------------- | ------- | ------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | boa¹            | Boa             | CLI     | Any                 | [Download](https://github.com/boa-dev/boa/releases/tag/nightly)                     |                                                                                                                                                                                                                 |
-| d8¹             | V8              | CLI     | Any                 | Build [from source](https://github.com/v8/v8)                                       | V8 console host. Errors are reported on stdout. Use `$262.getGlobal` and `$262.setGlobal` to get and set properties of global objects in other realms.                                                          |
+| d8¹             | V8              | CLI     | Any                 | Build [from source](https://github.com/v8/v8)                                       | V8 console host. Errors are reported on stdout.                                                                                                                                                                 |
 | engine262       | Engine262       | CLI     | Any                 | Build [from source](https://github.com/engine262/engine262)                         | An implementation of ECMA-262 in JavaScript.                                                                                                                                                                    |
 | graaljs         | GraalJS         | CLI     | Any                 | [Download](https://github.com/graalvm/graalvm-ce-builds)                            |                                                                                                                                                                                                                 |
 | jsshell¹        | SpiderMonkey    | CLI     | Any                 | [Download](https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/) | SpiderMonkey console host.                                                                                                                                                                                      |
@@ -214,14 +214,6 @@ Scripts are different from eval in that lexical bindings go into the global lexi
 ### `$262.destroy()`
 
 Destroys the realm. Note that in some hosts, $262.destroy may not actually stop executing code in the realm or even destroy the realm.
-
-### `$262.getGlobal(name)`
-
-Gets a global property name.
-
-### `$262.setGlobal(name, value)`
-
-Sets a global property name to value.
 
 ## Running the tests
 

--- a/runtimes/boa.js
+++ b/runtimes/boa.js
@@ -38,12 +38,6 @@ var $262 = {
       return { type: "throw", value: e };
     }
   },
-  getGlobal(name) {
-    return this.global[name];
-  },
-  setGlobal(name, value) {
-    this.global[name] = value;
-  },
   destroy() {
     /* noop */
   },

--- a/runtimes/browser.js
+++ b/runtimes/browser.js
@@ -76,12 +76,6 @@
         return { type: "normal", value: undefined };
       }
     },
-    getGlobal(name) {
-      return this.global[name];
-    },
-    setGlobal(name, value) {
-      this.global[name] = value;
-    },
     destroy() {
       $262.socket.emit("destroy");
     },

--- a/runtimes/d8.js
+++ b/runtimes/d8.js
@@ -31,12 +31,6 @@ var $262 = {
       return { type: "throw", value: e };
     }
   },
-  getGlobal(name) {
-    return this.global[name];
-  },
-  setGlobal(name, value) {
-    this.global[name] = value;
-  },
   destroy() {
     /* noop */
   },

--- a/runtimes/engine262.js
+++ b/runtimes/engine262.js
@@ -16,10 +16,6 @@
 
     return realm;
   };
-  $262.getGlobal = (name) => $262.global[name];
-  $262.setGlobal = (name, value) => {
-    $262.global[name] = value;
-  };
   $262.destroy = () => {};
   $262.source = $SOURCE;
 }

--- a/runtimes/graaljs.js
+++ b/runtimes/graaljs.js
@@ -10,12 +10,6 @@ $262.global = globalThis;
 $262.gc = function () {
   throw new Test262Error("gc() not yet supported.");
 };
-$262.getGlobal = function (name) {
-  return this.global[name];
-};
-$262.setGlobal = function (name, value) {
-  this.global[name] = value;
-};
 $262.destroy = function () {
   /* noop */
 };
@@ -34,8 +28,6 @@ $262.createRealm = function (options = {}) {
   const realm = DollarCreateRealm(options);
   realm.evalScript($262.source);
   realm.source = $262.source;
-  realm.getGlobal = $262.getGlobal;
-  realm.setGlobal = $262.setGlobal;
   realm.destroy = () => {
     if (options.destroy) {
       options.destroy();

--- a/runtimes/hermes.js
+++ b/runtimes/hermes.js
@@ -9,12 +9,6 @@ var $262 = {
   evalScript(code) {
     throw new Test262Error("evalScript() not yet supported.");
   },
-  getGlobal(name) {
-    return this.global[name];
-  },
-  setGlobal(name, value) {
-    this.global[name] = value;
-  },
   destroy() {
     /* noop */
   },

--- a/runtimes/jsc.js
+++ b/runtimes/jsc.js
@@ -14,12 +14,6 @@ Object.getOwnPropertyNames(jsc).forEach(function (name) {
 $262.global = globalThis;
 $262.source = $SOURCE;
 $262.destroy = function () {};
-$262.getGlobal = function (name) {
-  return this.global[name];
-};
-$262.setGlobal = function (name, value) {
-  this.global[name] = value;
-};
 $262.gc = function () {
   return gc();
 };
@@ -35,8 +29,6 @@ $262.createRealm = function (options = {}) {
   const realm = DollarCreateRealm(options);
   realm.evalScript($262.source);
   realm.source = $262.source;
-  realm.getGlobal = $262.getGlobal;
-  realm.setGlobal = $262.setGlobal;
   realm.destroy = () => {
     if (options.destroy) {
       options.destroy();

--- a/runtimes/jsshell.js
+++ b/runtimes/jsshell.js
@@ -29,12 +29,6 @@ var $262 = {
       return { type: "throw", value: e };
     }
   },
-  getGlobal(name) {
-    return this.global[name];
-  },
-  setGlobal(name, value) {
-    this.global[name] = value;
-  },
   destroy() {
     /* noop */
   },

--- a/runtimes/kiesel.js
+++ b/runtimes/kiesel.js
@@ -24,12 +24,6 @@ var $262 = {
       return { type: "throw", value: e };
     }
   },
-  getGlobal(name) {
-    return this.global[name];
-  },
-  setGlobal(name, value) {
-    this.global[name] = value;
-  },
   destroy() {
     /* noop */
   },

--- a/runtimes/libjs.js
+++ b/runtimes/libjs.js
@@ -12,12 +12,6 @@ var $262 = {
   evalScript(code) {
     throw new InternalError("evalScript() not yet supported.");
   },
-  getGlobal(name) {
-    return this.global[name];
-  },
-  setGlobal(name, value) {
-    this.global[name] = value;
-  },
   destroy() {
     /* noop */
   },

--- a/runtimes/nashorn.js
+++ b/runtimes/nashorn.js
@@ -30,12 +30,6 @@ var $262 = {
       return { type: "throw", value: e };
     }
   },
-  getGlobal: function (name) {
-    return this.global[name];
-  },
-  setGlobal: function (name, value) {
-    this.global[name] = value;
-  },
   destroy: function () {
     /* noop */
   },

--- a/runtimes/node.js
+++ b/runtimes/node.js
@@ -46,12 +46,6 @@ var $262 = {
       return { type: "throw", value: e };
     }
   },
-  getGlobal(name) {
-    return this.global[name];
-  },
-  setGlobal(name, value) {
-    this.global[name] = value;
-  },
   destroy() {
     /* noop */
   },

--- a/runtimes/qjs.js
+++ b/runtimes/qjs.js
@@ -9,12 +9,6 @@ $262.destroy = function () {};
 $262.gc = function () {
   throw new Test262Error("gc() not yet supported.");
 };
-$262.getGlobal = function (name) {
-  return this.global[name];
-};
-$262.setGlobal = function (name, value) {
-  this.global[name] = value;
-};
 $262.evalScript = function (code) {
   try {
     DollarEvalScript(code);
@@ -27,8 +21,6 @@ $262.createRealm = function (options = {}) {
   const realm = DollarCreateRealm(options);
   realm.evalScript($262.source);
   realm.source = $262.source;
-  realm.getGlobal = $262.getGlobal;
-  realm.setGlobal = $262.setGlobal;
   realm.destroy = () => {
     if (options.destroy) {
       options.destroy();

--- a/runtimes/xs.js
+++ b/runtimes/xs.js
@@ -17,12 +17,6 @@ if (!$262) {
     gc() {
       throw new Test262Error("gc() not yet supported.");
     },
-    getGlobal(name) {
-      return global[name];
-    },
-    setGlobal(name, value) {
-      global[name] = value;
-    },
     agent: (function () {
       function thrower() {
         throw new Test262Error("agent.* not yet supported.");
@@ -39,10 +33,4 @@ if (!$262) {
 }
 /* No IsHTMLDDA */
 $262.destroy = function () {};
-$262.getGlobal = function (name) {
-  return this.global[name];
-};
-$262.setGlobal = function (name, value) {
-  this.global[name] = value;
-};
 $262.source = $SOURCE;

--- a/test/runify.js
+++ b/test/runify.js
@@ -670,49 +670,6 @@ hosts.forEach(function (record) {
         `);
       });
 
-      it("can set properties in new realms", async () => {
-        if (["hermes", "libjs"].includes(type)) {
-          return;
-        }
-
-        const result = await agent.evalScript(stripIndent`
-          var realm = $262.createRealm({});
-          realm.evalScript("var x = 1");
-          realm.evalScript("print(x)");
-          realm.setGlobal("x", 2);
-          realm.evalScript("print(x)");
-        `);
-        expect(result).toMatchInlineSnapshot(`
-          {
-            "error": null,
-            "stderr": "",
-            "stdout": "1
-          2
-          ",
-          }
-        `);
-      });
-
-      it("can access properties from new realms", async () => {
-        if (["hermes", "libjs"].includes(type)) {
-          return;
-        }
-
-        const result = await agent.evalScript(stripIndent`
-          var realm = $262.createRealm({});
-          realm.evalScript("var x = 1");
-          print(realm.getGlobal("x"));
-        `);
-        expect(result).toMatchInlineSnapshot(`
-          {
-            "error": null,
-            "stderr": "",
-            "stdout": "1
-          ",
-          }
-        `);
-      });
-
       it("runs async code", async () => {
         const result = await agent.evalScript(
           stripIndent`


### PR DESCRIPTION
Every runtime implements this as thin wrapper around `$262.global` property access which is pointless. They're also not part of the test262 API.